### PR TITLE
Remove unused Font Awesome script

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="shortcut icon" href="/favicon.ico" />
-    <script src="https://use.fontawesome.com/4e50776f88.js"></script>
     <title>Cennik - Profi Bike</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,6 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-    <script src="https://use.fontawesome.com/4e50776f88.js"></script>
-
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
## Summary
- Remove the external Font Awesome script from the Vite HTML entry point.
- Remove the same unused script from the legacy public HTML template.
- Confirm no Font Awesome script or fa-* markup remains.

## Verification
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm build
- pnpm exec playwright test tests/e2e/print-queue.spec.ts --project=chromium --reporter=list

Closes #9