### PR TITLE
Fix observability chunk preloads

### DIFF
--- a/src/buildConfig.test.ts
+++ b/src/buildConfig.test.ts
@@ -13,8 +13,9 @@ describe("Vite production build config", () => {
     expect(getProductionChunkName("/project/node_modules/@firebase/database/dist/index.js")).toBe("vendor-firebase");
     expect(getProductionChunkName("/project/node_modules/@sentry/react/build/index.js")).toBe("vendor-observability");
     expect(getProductionChunkName("/project/node_modules/.pnpm/@sentry-internal+replay@10.52.0/node_modules/@sentry-internal/replay/build/npm/index.js")).toBe("vendor-sentry-replay");
-    expect(getProductionChunkName("/project/src/services/observability/browserObservability.ts")).toBe("observability");
-    expect(getProductionChunkName("/project/src/services/observability/singleton.ts")).toBe("observability");
+    expect(getProductionChunkName("/project/src/services/observability/browserObservability.ts")).toBeUndefined();
+    expect(getProductionChunkName("/project/src/services/observability/index.ts")).toBeUndefined();
+    expect(getProductionChunkName("/project/src/services/observability/singleton.ts")).toBeUndefined();
   });
 
   it("enables hidden source maps only when Sentry upload credentials exist", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,11 +29,6 @@ export const productionCodeSplittingGroups = [
     priority: 30
   },
   {
-    name: 'observability',
-    test: /src[\\/]services[\\/]observability[\\/]/,
-    priority: 20
-  },
-  {
     name: 'vendor',
     test: /node_modules[\\/]/,
     priority: 10


### PR DESCRIPTION
## Summary
- remove the app-source observability chunk group so the facade/error boundary stay in the entry bundle and browser observability remains behind the dynamic import
- keep Sentry vendor chunk grouping and source-map upload gating unchanged
- update build-config coverage to assert observability source files are not forced into a production preload chunk

Fixes #6

## Validation
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm build
- VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/1 pnpm build

Verified the no-telemetry production dist/index.html no longer modulepreloads vendor-sentry-replay, vendor-observability, or browserObservability chunks.