### PR TITLE
Fix admin promo toggle editing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -838,6 +838,84 @@
   border-color: var(--pb-accent);
 }
 
+.admin-promo-cell {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.admin-promo-toggle {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 18px;
+  position: relative;
+  width: 30px;
+}
+
+.admin-promo-toggle input {
+  appearance: none;
+  cursor: pointer;
+  height: 100%;
+  inset: 0;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.admin-promo-switch {
+  background: var(--pb-line);
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(23, 23, 26, 0.08);
+  display: block;
+  height: 18px;
+  position: relative;
+  transition: background 120ms ease, box-shadow 120ms ease;
+  width: 30px;
+}
+
+.admin-promo-switch::after {
+  background: var(--pb-surface);
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(23, 23, 26, 0.22);
+  content: "";
+  height: 14px;
+  left: 2px;
+  position: absolute;
+  top: 2px;
+  transition: transform 120ms ease;
+  width: 14px;
+}
+
+.admin-promo-toggle[data-active="true"] .admin-promo-switch {
+  background: var(--pb-accent);
+  box-shadow: inset 0 0 0 1px rgba(193, 39, 45, 0.18);
+}
+
+.admin-promo-toggle[data-active="true"] .admin-promo-switch::after {
+  transform: translateX(12px);
+}
+
+.admin-promo-toggle input:focus-visible + .admin-promo-switch {
+  outline: 2px solid color-mix(in srgb, var(--pb-accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.admin-promo-cell .ds-input {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.admin-promo-cell .ds-input:disabled {
+  background: #f6f5f2;
+  color: var(--pb-muted);
+  cursor: not-allowed;
+}
+
 .admin-status {
   color: var(--pb-muted);
   font-size: 11.5px;

--- a/src/domains/catalog/catalogDraft.ts
+++ b/src/domains/catalog/catalogDraft.ts
@@ -6,6 +6,7 @@ export type CatalogDraft = {
   year: string;
   price: string;
   discountPrice: string;
+  discountEnabled: boolean;
 };
 
 export function draftFromItem(item: CatalogItem): CatalogDraft {
@@ -14,7 +15,8 @@ export function draftFromItem(item: CatalogItem): CatalogDraft {
     model: item.model,
     year: String(item.year || ""),
     price: String(item.price || ""),
-    discountPrice: item.discountPrice ? String(item.discountPrice) : ""
+    discountPrice: item.discountPrice ? String(item.discountPrice) : "",
+    discountEnabled: item.discountEnabled
   };
 }
 
@@ -24,7 +26,8 @@ export function emptyCatalogDraft(defaultYear = new Date().getFullYear()): Catal
     model: "",
     year: String(defaultYear),
     price: "",
-    discountPrice: ""
+    discountPrice: "",
+    discountEnabled: false
   };
 }
 
@@ -39,7 +42,8 @@ export function isDraftValid(draft: CatalogDraft): boolean {
     Number.isFinite(price) &&
     price >= 0 &&
     Number.isFinite(discountPrice) &&
-    discountPrice >= 0
+    discountPrice >= 0 &&
+    (!draft.discountEnabled || discountPrice > 0)
   );
 }
 
@@ -52,7 +56,7 @@ export function catalogDraftToItem(draft: CatalogDraft): CatalogItemInput {
     year: draft.year.trim(),
     price: Number(draft.price),
     discountPrice,
-    discountEnabled: discountPrice > 0
+    discountEnabled: draft.discountEnabled
   };
 }
 

--- a/src/features/catalog/CatalogAdminScreen.test.tsx
+++ b/src/features/catalog/CatalogAdminScreen.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
 import CatalogAdminScreen from "./CatalogAdminScreen";
@@ -37,18 +38,23 @@ const products: CatalogProduct[] = [
   }
 ];
 
-function renderCatalogAdmin(catalogProducts = products) {
+function renderCatalogAdmin(catalogProducts = products, overrides: Partial<ComponentProps<typeof CatalogAdminScreen>> = {}) {
+  const props = {
+    brands: ["Giant", "Kross", "Trek"],
+    catalogError: "",
+    onAddProduct: vi.fn(async () => undefined),
+    onApplyBulkPromotion: vi.fn(async () => undefined),
+    onBackToPrint: vi.fn(),
+    onDeleteProduct: vi.fn(async () => undefined),
+    onDeleteProducts: vi.fn(async () => undefined),
+    onUpdateProduct: vi.fn(async () => undefined),
+    products: catalogProducts,
+    ...overrides
+  };
+
   return render(
     <CatalogAdminScreen
-      brands={["Giant", "Kross", "Trek"]}
-      catalogError=""
-      onAddProduct={vi.fn(async () => undefined)}
-      onApplyBulkPromotion={vi.fn(async () => undefined)}
-      onBackToPrint={vi.fn()}
-      onDeleteProduct={vi.fn(async () => undefined)}
-      onDeleteProducts={vi.fn(async () => undefined)}
-      onUpdateProduct={vi.fn(async () => undefined)}
-      products={catalogProducts}
+      {...props}
     />
   );
 }
@@ -136,5 +142,73 @@ describe("CatalogAdminScreen", () => {
     const addRow = screen.getByTestId("admin-add-row");
     expect(within(addRow).getByLabelText("Marka")).toHaveValue("");
     expect(within(addRow).getByLabelText("Rocznik")).toHaveValue(String(new Date().getFullYear()));
+  });
+
+  it("preserves inactive promotion status when an item has a stored promotion price", async () => {
+    const user = userEvent.setup();
+    const onUpdateProduct = vi.fn(async () => undefined);
+    const catalogProducts: CatalogProduct[] = [
+      {
+        brand: "Kross",
+        discountPrice: 14500,
+        discountEnabled: false,
+        id: "item-dormant-promo",
+        model: "Moon",
+        price: 14999,
+        year: 2026,
+        yearLabel: "2026"
+      }
+    ];
+    renderCatalogAdmin(catalogProducts, { onUpdateProduct });
+
+    const row = screen.getByTestId("admin-product-row");
+    expect(within(row).getByText("—")).toBeInTheDocument();
+
+    await user.click(within(row).getByRole("button", { name: "Edytuj" }));
+
+    const editedRow = screen.getByTestId("admin-product-row");
+    expect(within(editedRow).getByRole("checkbox", { name: "Promocja aktywna" })).not.toBeChecked();
+    expect(within(editedRow).getByLabelText("Cena promocyjna")).toHaveValue("14500");
+    expect(within(editedRow).getByLabelText("Cena promocyjna")).toBeDisabled();
+
+    await user.clear(within(editedRow).getByLabelText("Model"));
+    await user.type(within(editedRow).getByLabelText("Model"), "Moon Edited");
+    await user.click(within(editedRow).getByRole("button", { name: "Zapisz" }));
+
+    expect(onUpdateProduct).toHaveBeenCalledWith("item-dormant-promo", expect.objectContaining({
+      discountPrice: 14500,
+      discountEnabled: false,
+      model: "Moon Edited"
+    }));
+  });
+
+  it("enables promotion explicitly from the edit row toggle", async () => {
+    const user = userEvent.setup();
+    const onUpdateProduct = vi.fn(async () => undefined);
+    const catalogProducts: CatalogProduct[] = [
+      {
+        brand: "Kross",
+        discountPrice: 14500,
+        discountEnabled: false,
+        id: "item-dormant-promo",
+        model: "Moon",
+        price: 14999,
+        year: 2026,
+        yearLabel: "2026"
+      }
+    ];
+    renderCatalogAdmin(catalogProducts, { onUpdateProduct });
+
+    const row = screen.getByTestId("admin-product-row");
+    await user.click(within(row).getByRole("button", { name: "Edytuj" }));
+
+    const editedRow = screen.getByTestId("admin-product-row");
+    await user.click(within(editedRow).getByRole("checkbox", { name: "Promocja aktywna" }));
+    await user.click(within(editedRow).getByRole("button", { name: "Zapisz" }));
+
+    expect(onUpdateProduct).toHaveBeenCalledWith("item-dormant-promo", expect.objectContaining({
+      discountPrice: 14500,
+      discountEnabled: true
+    }));
   });
 });

--- a/src/features/catalog/CatalogAdminScreen.tsx
+++ b/src/features/catalog/CatalogAdminScreen.tsx
@@ -45,9 +45,11 @@ type CatalogAdminScreenProps = {
   onUpdateProduct(productId: string, item: CatalogItemInput): Promise<void>;
 };
 
-const draftFields: Array<keyof CatalogDraft> = ["brand", "model", "year", "price", "discountPrice"];
+type CatalogDraftTextField = Exclude<keyof CatalogDraft, "discountEnabled">;
 
-function fieldPlaceholder(field: keyof CatalogDraft): string {
+const draftFields: CatalogDraftTextField[] = ["brand", "model", "year", "price", "discountPrice"];
+
+function fieldPlaceholder(field: CatalogDraftTextField): string {
   return {
     brand: "Marka",
     model: "Model",
@@ -57,7 +59,12 @@ function fieldPlaceholder(field: keyof CatalogDraft): string {
   }[field];
 }
 
+function isNumericDraftField(field: CatalogDraftTextField): boolean {
+  return field === "price" || field === "discountPrice" || field === "year";
+}
+
 function isFieldDirty(product: CatalogItem, draft: CatalogDraft, field: keyof CatalogDraft): boolean {
+  if (field === "discountEnabled") return draft.discountEnabled !== product.discountEnabled;
   if (field === "discountPrice") return Number(draft.discountPrice || 0) !== Number(product.discountPrice);
   if (field === "price") return Number(draft.price) !== Number(product.price);
   if (field === "year") return String(draft.year) !== String(product.year);
@@ -281,14 +288,23 @@ const CatalogAdminScreen = ({
           <div className={`admin-row admin-row--editing${bulkMode ? " admin-row--bulk-editing" : ""}`} data-testid="admin-add-row">
             {bulkMode ? <span /> : null}
             {draftFields.map(field => (
-              <TextField
-                aria-label={fieldPlaceholder(field)}
-                key={field}
-                numeric={field === "price" || field === "discountPrice" || field === "year"}
-                onChange={event => updateNewDraft(field, event.target.value)}
-                placeholder={fieldPlaceholder(field)}
-                value={newDraft[field]}
-              />
+              field === "discountPrice" ? (
+                <PromoDraftCell
+                  draft={newDraft}
+                  key={field}
+                  onDiscountEnabledChange={value => updateNewDraft("discountEnabled", value)}
+                  onDiscountPriceChange={value => updateNewDraft("discountPrice", value)}
+                />
+              ) : (
+                <TextField
+                  aria-label={fieldPlaceholder(field)}
+                  key={field}
+                  numeric={isNumericDraftField(field)}
+                  onChange={event => updateNewDraft(field, event.target.value)}
+                  placeholder={fieldPlaceholder(field)}
+                  value={newDraft[field]}
+                />
+              )
             ))}
             <div className="admin-row__actions">
               <Button onClick={() => setAdding(false)} variant="ghost">Anuluj</Button>
@@ -314,15 +330,28 @@ const CatalogAdminScreen = ({
               >
                 {bulkMode ? <span /> : null}
                 {draftFields.map(field => (
-                  <TextField
-                    aria-label={fieldPlaceholder(field)}
-                    className={isFieldDirty(product, draft, field) ? "admin-input--dirty" : ""}
-                    key={field}
-                    numeric={field === "price" || field === "discountPrice" || field === "year"}
-                    onChange={event => updateDraft(product.id, field, event.target.value)}
-                    placeholder={fieldPlaceholder(field)}
-                    value={draft[field]}
-                  />
+                  field === "discountPrice" ? (
+                    <PromoDraftCell
+                      dirty={
+                        isFieldDirty(product, draft, "discountPrice") ||
+                        isFieldDirty(product, draft, "discountEnabled")
+                      }
+                      draft={draft}
+                      key={field}
+                      onDiscountEnabledChange={value => updateDraft(product.id, "discountEnabled", value)}
+                      onDiscountPriceChange={value => updateDraft(product.id, "discountPrice", value)}
+                    />
+                  ) : (
+                    <TextField
+                      aria-label={fieldPlaceholder(field)}
+                      className={isFieldDirty(product, draft, field) ? "admin-input--dirty" : ""}
+                      key={field}
+                      numeric={isNumericDraftField(field)}
+                      onChange={event => updateDraft(product.id, field, event.target.value)}
+                      placeholder={fieldPlaceholder(field)}
+                      value={draft[field]}
+                    />
+                  )
                 ))}
                 <div className="admin-row__actions">
                   <Button onClick={() => cancelEdit(product.id)} variant="ghost">Anuluj</Button>
@@ -369,8 +398,10 @@ const CatalogAdminScreen = ({
                     aria-label={`Usuń ${product.brand} ${product.model}`}
                     icon="trash"
                     onClick={() => openInlineDeleteConfirm(product)}
-                    variant="icon"
-                  />
+                    variant="ghost"
+                  >
+                    Usuń
+                  </Button>
                 </div>
               ) : null}
             </div>
@@ -413,6 +444,45 @@ const CatalogAdminScreen = ({
     </main>
   );
 };
+
+type PromoDraftCellProps = {
+  draft: CatalogDraft;
+  dirty?: boolean;
+  onDiscountEnabledChange(value: boolean): void;
+  onDiscountPriceChange(value: string): void;
+};
+
+const PromoDraftCell = ({
+  dirty = false,
+  draft,
+  onDiscountEnabledChange,
+  onDiscountPriceChange
+}: PromoDraftCellProps) => (
+  <div className="admin-promo-cell">
+    <label
+      className="admin-promo-toggle"
+      data-active={draft.discountEnabled ? "true" : "false"}
+      title="Promocja aktywna"
+    >
+      <input
+        aria-label="Promocja aktywna"
+        checked={draft.discountEnabled}
+        onChange={event => onDiscountEnabledChange(event.currentTarget.checked)}
+        type="checkbox"
+      />
+      <span className="admin-promo-switch" aria-hidden="true" />
+    </label>
+    <TextField
+      aria-label={fieldPlaceholder("discountPrice")}
+      className={dirty ? "admin-input--dirty" : ""}
+      disabled={!draft.discountEnabled}
+      numeric
+      onChange={event => onDiscountPriceChange(event.target.value)}
+      placeholder={fieldPlaceholder("discountPrice")}
+      value={draft.discountPrice}
+    />
+  </div>
+);
 
 type SelectionPillProps = {
   hiddenSelectedCount: number;

--- a/src/features/catalog/catalogViewModel.test.ts
+++ b/src/features/catalog/catalogViewModel.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { getUserInitials } from "../../app/authUser";
 import {
   catalogDraftToItem,
+  draftFromItem,
+  isDraftDirty,
   isDraftValid
 } from "../../domains/catalog/catalogDraft";
 import {
@@ -112,7 +114,8 @@ describe("catalog domain view models", () => {
       model: "Talon",
       year: "2026",
       price: "2999",
-      discountPrice: "2499"
+      discountPrice: "2499",
+      discountEnabled: true
     };
 
     expect(isDraftValid(draft)).toBe(true);
@@ -124,6 +127,43 @@ describe("catalog domain view models", () => {
       discountPrice: 2499,
       discountEnabled: true
     });
+  });
+
+  it("keeps inactive legacy promotion prices separate from promotion status", () => {
+    const product = {
+      id: "item3",
+      brand: "Kross",
+      model: "Moon",
+      year: "2026",
+      price: 14999,
+      discountPrice: 14500,
+      discountEnabled: false
+    };
+    const draft = draftFromItem(product);
+
+    expect(draft).toMatchObject({
+      discountPrice: "14500",
+      discountEnabled: false
+    });
+    expect(isDraftValid(draft)).toBe(true);
+    expect(isDraftDirty(product, draft)).toBe(false);
+    expect(catalogDraftToItem(draft)).toMatchObject({
+      discountPrice: 14500,
+      discountEnabled: false
+    });
+  });
+
+  it("requires a positive promotion price when promotion is enabled", () => {
+    expect(
+      isDraftValid({
+        brand: "Kross",
+        model: "Level",
+        year: "2026",
+        price: "2999",
+        discountPrice: "",
+        discountEnabled: true
+      })
+    ).toBe(false);
   });
 
   it("derives user initials from display name or email", () => {

--- a/src/features/catalog/useCatalogEditor.ts
+++ b/src/features/catalog/useCatalogEditor.ts
@@ -48,8 +48,8 @@ export type CatalogEditorState = {
   setYear(year: string): void;
   startAdding(): void;
   startEdit(product: CatalogProduct): void;
-  updateDraft(productId: string, field: keyof CatalogDraft, value: string): void;
-  updateNewDraft(field: keyof CatalogDraft, value: string): void;
+  updateDraft<K extends keyof CatalogDraft>(productId: string, field: K, value: CatalogDraft[K]): void;
+  updateNewDraft<K extends keyof CatalogDraft>(field: K, value: CatalogDraft[K]): void;
 };
 
 export function useCatalogEditor({
@@ -98,7 +98,7 @@ export function useCatalogEditor({
     [activeBrand, activeYear, products, query]
   );
 
-  const updateDraft = useCallback((productId: string, field: keyof CatalogDraft, value: string) => {
+  const updateDraft = useCallback(<K extends keyof CatalogDraft>(productId: string, field: K, value: CatalogDraft[K]) => {
     setDrafts(current => ({
       ...current,
       [productId]: {
@@ -108,7 +108,7 @@ export function useCatalogEditor({
     }));
   }, []);
 
-  const updateNewDraft = useCallback((field: keyof CatalogDraft, value: string) => {
+  const updateNewDraft = useCallback(<K extends keyof CatalogDraft>(field: K, value: CatalogDraft[K]) => {
     setNewDraft(current => ({ ...current, [field]: value }));
   }, []);
 


### PR DESCRIPTION
## Summary
- Preserve the legacy `discountStatus` flag independently from `discountPrice` in catalog edit drafts
- Add a compact inline promo switch in the admin edit/add row
- Align inline `Edytuj` and `Usuń` row actions and cover dormant promo-price behavior in tests

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:e2e

Also verified against the production DB export: rows with `discountStatus: off` and positive `discountPrice` keep promo disabled while retaining the stored value.