### PR TITLE
Hide legacy catalog DB shape in repository

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -35,10 +35,11 @@ it('tracks screen changes and print workflow events', async () => {
     subscribeCatalogItems: vi.fn(handlers => {
       handlers.next({
         item1: {
+          brand: 'KTM',
           discountPrice: 0,
-          discountStatus: 'off',
+          discountEnabled: false,
+          id: 'item1',
           model: 'Scarp',
-          name: 'KTM',
           price: 12999,
           year: 2026
         }

--- a/src/features/bulkPromotion/useBulkPromotionActions.test.tsx
+++ b/src/features/bulkPromotion/useBulkPromotionActions.test.tsx
@@ -57,12 +57,9 @@ describe("useBulkPromotionActions", () => {
     });
 
     const promotedItem = {
-      name: "KTM",
-      model: "Scarp",
-      price: 1000,
+      ...catalogItems.item1,
       discountPrice: 700,
-      discountStatus: "on" as const,
-      year: 2026
+      discountEnabled: true
     };
     expect(repository.saveCatalogItems).toHaveBeenCalledWith({ item1: promotedItem });
     expect(repository.saveCatalogItem).not.toHaveBeenCalled();

--- a/src/features/bulkPromotion/useBulkPromotionActions.ts
+++ b/src/features/bulkPromotion/useBulkPromotionActions.ts
@@ -1,8 +1,5 @@
 import { useCallback } from "react";
-import {
-  catalogItemsToLegacyCatalogItems,
-  type CatalogItemsById
-} from "../../domains/catalog/catalogItem";
+import type { CatalogItemsById } from "../../domains/catalog/catalogItem";
 import {
   type CatalogWriteRepository,
   toFirebaseRepositoryError
@@ -45,9 +42,9 @@ export function useBulkPromotionActions({
     if (updates.length === 0) return;
 
     try {
-      await repository.saveCatalogItems(catalogItemsToLegacyCatalogItems(Object.fromEntries(
+      await repository.saveCatalogItems(Object.fromEntries(
         updates.map(({ productId, item }) => [productId, item])
-      )));
+      ));
       observability.trackEvent("bulk_promotion_apply", {
         discount_mode: options.mode,
         selected_item_count: updates.length

--- a/src/features/catalog/useCatalog.test.tsx
+++ b/src/features/catalog/useCatalog.test.tsx
@@ -1,7 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AuthUser } from "../../domains/auth/authUser";
-import type { CatalogBrands, LegacyCatalogItemsById } from "../../domains/catalog/catalog";
+import type { CatalogBrands } from "../../domains/catalog/catalog";
+import type { CatalogItemsById } from "../../domains/catalog/catalogItem";
 import type {
   CatalogReadRepository,
   FirebaseRepositoryError
@@ -15,7 +16,7 @@ type SubscriptionHandlers<T> = {
 };
 
 function createCatalogRepository() {
-  let itemHandlers: SubscriptionHandlers<LegacyCatalogItemsById> | null = null;
+  let itemHandlers: SubscriptionHandlers<CatalogItemsById> | null = null;
   let brandHandlers: SubscriptionHandlers<CatalogBrands> | null = null;
   const unsubscribeItems = vi.fn();
   const unsubscribeBrands = vi.fn();
@@ -34,7 +35,7 @@ function createCatalogRepository() {
     emitBrands(brands: CatalogBrands) {
       act(() => brandHandlers?.next(brands));
     },
-    emitItems(items: LegacyCatalogItemsById) {
+    emitItems(items: CatalogItemsById) {
       act(() => itemHandlers?.next(items));
     },
     failItems(error: FirebaseRepositoryError) {
@@ -49,10 +50,11 @@ function createCatalogRepository() {
 const user: AuthUser = { displayName: null, email: "owner@example.test", uid: "owner" };
 
 const item = {
+  brand: "KTM",
   discountPrice: 0,
-  discountStatus: "off" as const,
+  discountEnabled: false,
+  id: "item1",
   model: "Scarp",
-  name: "KTM",
   price: 12999,
   year: 2026
 };
@@ -85,15 +87,7 @@ describe("useCatalog", () => {
     });
     expect(result.current.catalogLoading).toBe(false);
     expect(result.current.catalogItems).toEqual({
-      item1: {
-        brand: "KTM",
-        discountEnabled: false,
-        discountPrice: 0,
-        id: "item1",
-        model: "Scarp",
-        price: 12999,
-        year: 2026
-      }
+      item1: item
     });
     expect(result.current.products).toEqual([
       {

--- a/src/features/catalog/useCatalog.ts
+++ b/src/features/catalog/useCatalog.ts
@@ -6,10 +6,7 @@ import {
   type CatalogErrorHandler
 } from "./catalogErrors";
 import type { CatalogBrands } from "../../domains/catalog/catalog";
-import {
-  legacyCatalogItemsToCatalogItems,
-  type CatalogItemsById
-} from "../../domains/catalog/catalogItem";
+import type { CatalogItemsById } from "../../domains/catalog/catalogItem";
 import type { CatalogReadRepository } from "../../services/firebase";
 import {
   observability as defaultObservability,
@@ -68,16 +65,15 @@ export function useCatalog(
 
     const unsubscribeItems = repository.subscribeCatalogItems({
       next: items => {
-        const catalogItems = legacyCatalogItemsToCatalogItems(items);
         setCatalogData(currentData => ({
           ...currentData,
           error: "",
-          items: catalogItems,
+          items,
           itemsLoadedForUid: activeUid
         }));
         if (!trackedCatalogLoadsRef.current.has(activeUid)) {
           observability.trackEvent("catalog_load_success", {
-            item_count: Object.keys(catalogItems).length
+            item_count: Object.keys(items).length
           });
           trackedCatalogLoadsRef.current.add(activeUid);
         }

--- a/src/features/catalog/useCatalogMutations.test.tsx
+++ b/src/features/catalog/useCatalogMutations.test.tsx
@@ -25,15 +25,6 @@ const item: CatalogItemInput = {
   year: 2026
 };
 
-const legacyItem = {
-  discountPrice: 0,
-  discountStatus: "off" as const,
-  model: "Scarp",
-  name: "KTM",
-  price: 12999,
-  year: 2026
-};
-
 describe("useCatalogMutations", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -54,7 +45,7 @@ describe("useCatalogMutations", () => {
 
     await result.current.addCatalogItem(item);
 
-    expect(repository.saveCatalogItem).toHaveBeenCalledWith("item123", legacyItem);
+    expect(repository.saveCatalogItem).toHaveBeenCalledWith("item123", item);
     expect(observability.trackEvent).toHaveBeenCalledWith("catalog_item_create");
   });
 
@@ -72,7 +63,7 @@ describe("useCatalogMutations", () => {
     await result.current.addCatalogItem(item);
 
     expect(randomUUID).toHaveBeenCalled();
-    expect(repository.saveCatalogItem).toHaveBeenCalledWith("item-00000000-0000-4000-8000-000000000000", legacyItem);
+    expect(repository.saveCatalogItem).toHaveBeenCalledWith("item-00000000-0000-4000-8000-000000000000", item);
   });
 
   it("updates existing catalog items through the injected repository", async () => {
@@ -90,10 +81,7 @@ describe("useCatalogMutations", () => {
 
     await result.current.updateCatalogItem("item1", updatedItem);
 
-    expect(repository.saveCatalogItem).toHaveBeenCalledWith("item1", {
-      ...legacyItem,
-      price: 9999
-    });
+    expect(repository.saveCatalogItem).toHaveBeenCalledWith("item1", updatedItem);
     expect(observability.trackEvent).toHaveBeenCalledWith("catalog_item_update");
   });
 

--- a/src/features/catalog/useCatalogMutations.ts
+++ b/src/features/catalog/useCatalogMutations.ts
@@ -1,8 +1,5 @@
 import { useCallback } from "react";
-import {
-  catalogItemToLegacyCatalogItem,
-  type CatalogItemInput
-} from "../../domains/catalog/catalogItem";
+import type { CatalogItemInput } from "../../domains/catalog/catalogItem";
 import {
   type CatalogWriteRepository,
   toFirebaseRepositoryError
@@ -38,7 +35,7 @@ export function useCatalogMutations({
   const addCatalogItem = useCallback(async (item: CatalogItemInput) => {
     const key = createCatalogItemId();
     try {
-      await repository.saveCatalogItem(key, catalogItemToLegacyCatalogItem(item));
+      await repository.saveCatalogItem(key, item);
       observability.trackEvent("catalog_item_create");
     } catch (error) {
       const repositoryError = toFirebaseRepositoryError(error);
@@ -55,7 +52,7 @@ export function useCatalogMutations({
 
   const updateCatalogItem = useCallback(async (key: string, updatedItem: CatalogItemInput) => {
     try {
-      await repository.saveCatalogItem(key, catalogItemToLegacyCatalogItem(updatedItem));
+      await repository.saveCatalogItem(key, updatedItem);
       observability.trackEvent("catalog_item_update");
     } catch (error) {
       const repositoryError = toFirebaseRepositoryError(error);

--- a/src/services/firebase/catalogRepository.ts
+++ b/src/services/firebase/catalogRepository.ts
@@ -8,6 +8,13 @@ import {
   type LegacyCatalogItem,
   type LegacyCatalogItemsById
 } from '../../domains/catalog/catalog';
+import {
+  catalogItemsToLegacyCatalogItems,
+  catalogItemToLegacyCatalogItem,
+  legacyCatalogItemsToCatalogItems,
+  type CatalogItemInput,
+  type CatalogItemsById
+} from '../../domains/catalog/catalogItem';
 import type { RepositoryError } from './repositoryError';
 
 export const defaultStoreId = 'profi-bike';
@@ -32,13 +39,13 @@ export type SubscriptionHandlers<T> = {
 };
 
 export type CatalogReadRepository = {
-  subscribeCatalogItems(handlers: SubscriptionHandlers<LegacyCatalogItemsById>): () => void;
+  subscribeCatalogItems(handlers: SubscriptionHandlers<CatalogItemsById>): () => void;
   subscribeCatalogBrands(handlers: SubscriptionHandlers<CatalogBrands>): () => void;
 };
 
 export type CatalogWriteRepository = {
-  saveCatalogItem(itemId: string, item: LegacyCatalogItem): Promise<void>;
-  saveCatalogItems(items: LegacyCatalogItemsById): Promise<void>;
+  saveCatalogItem(itemId: string, item: CatalogItemInput): Promise<void>;
+  saveCatalogItems(items: Record<string, CatalogItemInput>): Promise<void>;
   deleteCatalogItem(itemId: string): Promise<void>;
   deleteCatalogItems(itemIds: string[]): Promise<void>;
 };
@@ -86,7 +93,7 @@ export function createCatalogRepository(
     subscribeCatalogItems({ next, error }) {
       return onValue(
         ref(database, catalogPaths.items(storeId)),
-        snapshot => next(parseLegacyCatalogItems(snapshot.val())),
+        snapshot => next(legacyCatalogItemsToCatalogItems(parseLegacyCatalogItems(snapshot.val()))),
         firebaseError => error?.(toFirebaseRepositoryError(firebaseError))
       );
     },
@@ -98,10 +105,14 @@ export function createCatalogRepository(
       );
     },
     saveCatalogItem(itemId, item) {
-      return set(ref(database, catalogPaths.item(itemId, storeId)), ensureWritableCatalogItem(item));
+      return set(
+        ref(database, catalogPaths.item(itemId, storeId)),
+        ensureWritableCatalogItem(catalogItemToLegacyCatalogItem(item))
+      );
     },
     saveCatalogItems(items) {
-      const writableItems = Object.entries(items).reduce<LegacyCatalogItemsById>((nextItems, [itemId, item]) => {
+      const legacyItems = catalogItemsToLegacyCatalogItems(items);
+      const writableItems = Object.entries(legacyItems).reduce<LegacyCatalogItemsById>((nextItems, [itemId, item]) => {
         nextItems[itemId] = ensureWritableCatalogItem(item);
         return nextItems;
       }, {});

--- a/src/services/firebase/index.ts
+++ b/src/services/firebase/index.ts
@@ -9,7 +9,6 @@ export type { AuthService } from './authService';
 export {
   catalogPaths,
   createCatalogRepository,
-  ensureWritableCatalogItem,
   isPermissionDenied,
   readCatalogBrands,
   toFirebaseRepositoryError

--- a/tests/catalogRepository.rules.test.ts
+++ b/tests/catalogRepository.rules.test.ts
@@ -16,7 +16,8 @@ import {
   type CatalogRepository,
   type FirebaseRepositoryError
 } from '../src/services/firebase/catalogRepository';
-import type { LegacyCatalogItem, LegacyCatalogItemsById } from '../src/domains/catalog/catalog';
+import type { LegacyCatalogItem } from '../src/domains/catalog/catalog';
+import type { CatalogItemInput, CatalogItemsById } from '../src/domains/catalog/catalogItem';
 
 let testEnv: RulesTestEnvironment;
 const databaseEmulator = readRulesDatabaseEmulatorConfig();
@@ -27,6 +28,15 @@ const validItem: LegacyCatalogItem = {
   price: 1000,
   discountPrice: 900,
   discountStatus: 'on',
+  year: 2026
+};
+
+const validCatalogItem: CatalogItemInput = {
+  brand: 'Kross',
+  model: 'Demo',
+  price: 1000,
+  discountPrice: 900,
+  discountEnabled: true,
   year: 2026
 };
 
@@ -70,7 +80,7 @@ async function seedCatalogData(): Promise<void> {
   });
 }
 
-function readItemsOnce(repository: CatalogRepository): Promise<LegacyCatalogItemsById> {
+function readItemsOnce(repository: CatalogRepository): Promise<CatalogItemsById> {
   return new Promise((resolve, reject) => {
     let unsubscribe: () => void = () => {};
     const timeout = setTimeout(() => {
@@ -138,13 +148,13 @@ describe('CatalogRepository security rules integration', () => {
 
     await assertSucceeds(set(ref(database, 'profi-bike/brands'), ['Kross']));
     await assertSucceeds(get(ref(database, 'profi-bike/brands')));
-    await assertSucceeds(repository.saveCatalogItem('item-1', validItem));
+    await assertSucceeds(repository.saveCatalogItem('item-1', validCatalogItem));
     await assertSucceeds(repository.saveCatalogItems({
-      'item-2': { ...validItem, model: 'Batch demo' }
+      'item-2': { ...validCatalogItem, model: 'Batch demo' }
     }));
     await expect(readItemsOnce(repository)).resolves.toEqual({
-      'item-1': validItem,
-      'item-2': { ...validItem, model: 'Batch demo' }
+      'item-1': { ...validCatalogItem, id: 'item-1' },
+      'item-2': { ...validCatalogItem, id: 'item-2', model: 'Batch demo' }
     });
 
     await assertSucceeds(repository.deleteCatalogItem('item-1'));
@@ -182,7 +192,7 @@ describe('CatalogRepository security rules integration', () => {
     const database = authenticatedDatabase('other-uid');
 
     await assertFails(get(ref(database, 'profi-bike/brands')));
-    await assertFails(repository.saveCatalogItem('item-1', validItem));
+    await assertFails(repository.saveCatalogItem('item-1', validCatalogItem));
     await assertFails(set(ref(database, 'profi-bike/brands'), ['Kross']));
     await assertFails(get(ref(database, 'profi-bike/owners')));
     await assertFails(get(ref(database, 'profi-bike/ownerUids')));
@@ -203,7 +213,7 @@ describe('CatalogRepository security rules integration', () => {
     await seedCatalogData();
 
     const repository = authenticatedRepository('owner-uid');
-    await assertSucceeds(repository.saveCatalogItem('item-2', { ...validItem, model: 'Second' }));
+    await assertSucceeds(repository.saveCatalogItem('item-2', { ...validCatalogItem, model: 'Second' }));
 
     await assertSucceeds(repository.deleteCatalogItems(['item-1', 'item-2']));
 
@@ -231,7 +241,7 @@ describe('CatalogRepository security rules integration', () => {
 
     const repository = authenticatedRepository('legacy-owner-uid');
 
-    await assertFails(repository.saveCatalogItem('item-1', validItem));
+    await assertFails(repository.saveCatalogItem('item-1', validCatalogItem));
     const deniedError = await readItemsDenied(repository);
     expect(isPermissionDenied(deniedError)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- update catalog repository read/write contracts to use normalized catalog domain types
- keep legacy Realtime Database parsing and serialization inside the Firebase service
- remove feature-level legacy conversions from catalog and bulk-promotion workflows

## QA
- pnpm typecheck
- pnpm exec vitest run src/services/firebase/catalogRepository.test.ts src/features/catalog/useCatalog.test.tsx src/features/catalog/useCatalogMutations.test.tsx src/features/bulkPromotion/useBulkPromotionActions.test.tsx
- pnpm test:rules