### PR TITLE
Codify domain and feature boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,14 @@ src/
       singleton.ts
 ```
 
+Domain/feature/service boundaries are documented in `docs/modernization/domain-feature-boundaries.md` and enforced by ESLint where the current codebase can support it. Use these placement rules:
+
+- Put pure business rules, parsing, calculations, stable model types, and reusable copy helpers in `src/domains/`. Domain code must not depend on React, app shell, feature workflows, service adapters, or design-system components.
+- Put screen workflows, hooks, view state, forms, modals, table composition, and user-action orchestration in `src/features/`. Feature code may consume domains, typed services, and design-system primitives, but must not import app-shell modules or Firebase/Sentry SDK modules directly.
+- Put Firebase, observability, and other external integration adapters in `src/services/` behind typed facades. Services may translate between external SDK/data shapes and domain types, but must not import feature UI, app shell, or design-system components.
+- Put generic UI primitives in `src/design-system/`. Design-system modules must not know about catalog, pricing, Firebase, observability, print queue, or app workflows.
+- Put top-level shell/routing/composition in `src/app/`. If app code accumulates reusable business rules, move that logic down into `domains/` or `services/`.
+
 React components must not import Firebase SDK modules directly. Use `authService` for authentication and `catalogRepository` for Realtime Database access. Use `src/services/observability` for Firebase Analytics and Sentry; feature code should receive or import the typed facade rather than importing SDKs.
 
 Feature components should consume domain/service data through typed view models. For the current redesign:

--- a/docs/modernization/domain-feature-boundaries.md
+++ b/docs/modernization/domain-feature-boundaries.md
@@ -1,0 +1,42 @@
+# Domain And Feature Boundaries
+
+## Purpose
+
+The modern app is small, but the catalog, pricing, print queue, and observability flows now have enough moving parts that shared logic needs a stable home. Use these rules when deciding whether new code belongs in `domains/`, `features/`, `services/`, `design-system/`, or `app/`.
+
+## Layer Rules
+
+| Layer | Owns | May depend on | Must not depend on |
+| --- | --- | --- | --- |
+| `domains/` | Business rules, data parsing, calculations, stable model types, copy helpers that are not tied to a screen | Other domains | React, app shell, feature workflows, service SDK adapters, design-system components |
+| `features/` | Screen workflows, hooks, view state, user actions, forms, tables, modals, feature-specific composition | Domains, services, design-system, sibling feature UI when intentionally composing a workflow | App shell, direct Firebase/Sentry SDK imports |
+| `services/` | Firebase, observability, and other integration adapters behind typed facades | Domains and external SDKs needed by the service | App shell, feature UI, design-system components |
+| `design-system/` | Generic visual primitives and interaction controls | React and local design-system modules | App-specific domains, features, services, app shell |
+| `app/` | Top-level composition, mode routing, shell/header/profile wiring | All app layers as needed | Business logic that should be reusable below the app layer |
+
+## Placement Heuristics
+
+Put code in `domains/` when it can run without React, browser globals, Firebase, Sentry, or screen state. Good domain code is easy to unit test with plain inputs and outputs: price math, catalog item parsing, filtering/sorting rules, queue mutation rules, print-tag expansion, language pluralization, and stable model types.
+
+Put code in `features/` when it coordinates user intent with UI state or services: hooks, click handlers, form drafts, selection state, dialogs, table rows, screen-specific labels, and calls to repositories or telemetry facades. If a feature helper starts being reused and does not need React or services, move it down to `domains/`.
+
+Put code in `services/` when it talks to an external system or wraps an SDK. Firebase schema adapters, auth, repository writes, Analytics, Sentry, and telemetry facades belong here. Feature code should call the typed service facade rather than importing SDK modules.
+
+Put code in `design-system/` only when it is reusable UI infrastructure. Do not add catalog, pricing, Firebase, observability, or print-queue knowledge to these components.
+
+## Current Exceptions
+
+`features/catalog/CatalogAdminScreen.tsx` composes `features/bulkPromotion/BulkPromotionModal.tsx` because the catalog admin screen owns that workflow. Keep this kind of feature-to-feature dependency explicit and UI-level. Shared calculations, copy, or data shaping from that workflow should live in `domains/`.
+
+`domains/storage` accepts a `StorageLike` dependency so queue persistence can be tested without directly reading browser globals. Keep browser access in features or app code and pass dependencies into domain helpers.
+
+## Enforcement
+
+`eslint.config.js` enforces the layer boundaries that are safe for the current codebase:
+
+- Domains cannot import React, app, design-system, feature, or service modules.
+- Features cannot import the app layer or direct Firebase/Sentry SDK modules.
+- Services cannot import app, design-system, or feature modules.
+- Design-system modules cannot import app-specific layers.
+
+When a lint rule blocks a change, move the shared contract to a lower layer instead of weakening the boundary locally.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,8 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
+const relativeLayerImportPattern = (layers) => `^(?:\\.\\./)+(?:${layers.join('|')})(?:/|$)`;
+
 export default tseslint.config(
   { ignores: ['dist', 'coverage', 'node_modules', 'emulator-data', 'Design system & app redesign'] },
   js.configs.recommended,
@@ -47,13 +49,68 @@ export default tseslint.config(
     }
   },
   {
-    files: ['src/{features,services,domains}/**/*.{ts,tsx}'],
+    files: ['src/domains/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': ['error', {
-        patterns: [{
-          group: ['../app/*', '../../app/*', '../../../app/*', '../../../../app/*'],
-          message: 'App-layer modules compose the application; move shared contracts into domains or services instead.'
-        }]
+        paths: [
+          {
+            name: 'react',
+            message: 'Domain modules must stay framework-free. Move React code to features or app.'
+          },
+          {
+            name: 'react-dom',
+            message: 'Domain modules must stay framework-free. Move React DOM code to features or app.'
+          }
+        ],
+        patterns: [
+          {
+            regex: relativeLayerImportPattern(['app', 'design-system', 'features', 'services']),
+            message: 'Domain modules must not depend on app, UI, feature, or service layers.'
+          }
+        ]
+      }]
+    }
+  },
+  {
+    files: ['src/features/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            regex: relativeLayerImportPattern(['app']),
+            message: 'App-layer modules compose features; move shared contracts into domains or services instead.'
+          },
+          {
+            group: ['firebase/*', '@sentry/*'],
+            message: 'Feature code must use the typed service layers instead of importing SDK modules directly.'
+          }
+        ]
+      }]
+    }
+  },
+  {
+    files: ['src/services/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            regex: relativeLayerImportPattern(['app', 'design-system', 'features']),
+            message: 'Service modules must not depend on app, UI, or feature layers.'
+          }
+        ]
+      }]
+    }
+  },
+  {
+    files: ['src/design-system/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            regex: relativeLayerImportPattern(['app', 'domains', 'features', 'services']),
+            message: 'Design-system primitives must stay generic and not depend on app-specific layers.'
+          }
+        ]
       }]
     }
   }


### PR DESCRIPTION
## Summary
- document the domain/feature/service/design-system placement rules
- add the same guidance to AGENTS.md for future agent work
- enforce current-safe layer boundaries with ESLint restricted imports

## QA
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build