### PR TITLE
Isolate Firebase runtime singletons

### DIFF
--- a/docs/modernization/domain-feature-boundaries.md
+++ b/docs/modernization/domain-feature-boundaries.md
@@ -22,6 +22,8 @@ Put code in `features/` when it coordinates user intent with UI state or service
 
 Put code in `services/` when it talks to an external system or wraps an SDK. Firebase schema adapters, auth, repository writes, Analytics, Sentry, and telemetry facades belong here. Feature code should call the typed service facade rather than importing SDK modules.
 
+Keep service barrels side-effect-free. Export factories, types, and pure helpers from `services/*/index.ts`; put app boot singletons in explicit runtime modules so feature-level imports do not initialize SDK clients.
+
 Put code in `design-system/` only when it is reusable UI infrastructure. Do not add catalog, pricing, Firebase, observability, or print-queue knowledge to these components.
 
 ## Current Exceptions

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,12 +15,8 @@ import { useCatalog } from "./features/catalog/useCatalog";
 import { useCatalogMutations } from "./features/catalog/useCatalogMutations";
 import PrintQueuePanel from "./features/printQueue/PrintQueuePanel";
 import { usePrintQueue } from "./features/printQueue/usePrintQueue";
-import {
-  authService,
-  catalogRepository,
-  type AuthService,
-  type CatalogRepository
-} from "./services/firebase";
+import type { AuthService, CatalogRepository } from "./services/firebase";
+import { authService, catalogRepository } from "./services/firebase/runtime";
 import type { StorageLike } from "./domains/storage/printQueueStorage";
 import {
   observability as defaultObservability,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 
 import './index.css';
 import App from './App';
-import { firebaseServices } from './services/firebase';
+import { firebaseServices } from './services/firebase/runtime';
 import { initializeObservability, ObservabilityErrorBoundary } from './services/observability';
 
 const rootElement = document.getElementById('root');

--- a/src/services/firebase/app.ts
+++ b/src/services/firebase/app.ts
@@ -40,5 +40,3 @@ export function createFirebaseServiceInstances(
     runtimeConfig
   };
 }
-
-export const firebaseServices = createFirebaseServiceInstances();

--- a/src/services/firebase/index.test.ts
+++ b/src/services/firebase/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("firebase service barrel", () => {
+  it("does not initialize Firebase when feature code imports service helpers", async () => {
+    vi.resetModules();
+    const initializeApp = vi.fn();
+
+    vi.doMock("firebase/app", () => ({
+      getApp: vi.fn(),
+      getApps: vi.fn(() => []),
+      initializeApp
+    }));
+    vi.doMock("firebase/auth", () => ({
+      connectAuthEmulator: vi.fn(),
+      getAuth: vi.fn()
+    }));
+    vi.doMock("firebase/database", () => ({
+      get: vi.fn(),
+      onValue: vi.fn(),
+      ref: vi.fn(),
+      remove: vi.fn(),
+      set: vi.fn(),
+      update: vi.fn()
+    }));
+
+    const firebaseExports = await import("./index");
+
+    expect(initializeApp).not.toHaveBeenCalled();
+    expect(firebaseExports.toFirebaseRepositoryError({ code: "permission-denied" }).code)
+      .toBe("permission-denied");
+  });
+});

--- a/src/services/firebase/index.ts
+++ b/src/services/firebase/index.ts
@@ -1,8 +1,4 @@
-import { firebaseServices } from './app';
-import { createAuthService } from './authService';
-import { createCatalogRepository } from './catalogRepository';
-
-export { firebaseServices, createFirebaseServiceInstances } from './app';
+export { createFirebaseServiceInstances } from './app';
 export type { FirebaseServiceInstances } from './app';
 export { createAuthService } from './authService';
 export type { AuthService } from './authService';
@@ -22,6 +18,3 @@ export type {
 } from './catalogRepository';
 export { readFirebaseRuntimeConfig } from './config';
 export type { RepositoryError } from './repositoryError';
-
-export const authService = createAuthService(firebaseServices.auth);
-export const catalogRepository = createCatalogRepository(firebaseServices.database);

--- a/src/services/firebase/runtime.ts
+++ b/src/services/firebase/runtime.ts
@@ -1,0 +1,7 @@
+import { createFirebaseServiceInstances } from "./app";
+import { createAuthService } from "./authService";
+import { createCatalogRepository } from "./catalogRepository";
+
+export const firebaseServices = createFirebaseServiceInstances();
+export const authService = createAuthService(firebaseServices.auth);
+export const catalogRepository = createCatalogRepository(firebaseServices.database);


### PR DESCRIPTION
## Summary
- move Firebase/Auth/Catalog live singletons into an explicit runtime module
- make the Firebase service barrel export factories, types, and pure helpers without initializing SDK clients
- update app boot imports and document the side-effect-free service barrel rule
- add a regression test proving helper imports do not initialize Firebase

## Audit item
- addresses #1: Firebase service barrel import-time side effects

## Verification
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm build
- pnpm test:e2e