### PR TITLE
Extract catalog admin workflow state

### DIFF
--- a/src/features/catalog/CatalogAdminScreen.tsx
+++ b/src/features/catalog/CatalogAdminScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { CatalogItemInput } from "../../domains/catalog/catalogItem";
 import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
 import { editingRowsLabel } from "../../domains/language/catalogCopy";
@@ -8,15 +8,10 @@ import CatalogAdminFilters from "./CatalogAdminFilters";
 import CatalogAdminHeader from "./CatalogAdminHeader";
 import CatalogAdminTable from "./CatalogAdminTable";
 import CatalogSelectionPill from "./CatalogSelectionPill";
-import type { CatalogAdminMode } from "./catalogAdminTypes";
 import DeleteConfirmModal from "./DeleteConfirmModal";
+import { useCatalogAdminWorkflow } from "./useCatalogAdminWorkflow";
 import { useCatalogEditor } from "./useCatalogEditor";
 import { useCatalogSelection } from "./useCatalogSelection";
-
-type DeleteConfirmState = {
-  mode: "quick" | "phrase";
-  products: CatalogProduct[];
-};
 
 type CatalogAdminScreenProps = {
   brands: string[];
@@ -41,10 +36,6 @@ const CatalogAdminScreen = ({
   onUpdateProduct,
   products
 }: CatalogAdminScreenProps) => {
-  const [adminMode, setAdminMode] = useState<CatalogAdminMode>("edit");
-  const [bulkPromotionOpen, setBulkPromotionOpen] = useState(false);
-  const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState | null>(null);
-  const bulkMode = adminMode === "bulk";
   const {
     adding,
     addProduct,
@@ -92,52 +83,32 @@ const CatalogAdminScreen = ({
     products,
     selectableFilteredProducts
   });
-
-  const toggleAdminMode = (nextMode: CatalogAdminMode) => {
-    setAdminMode(nextMode);
-    if (nextMode === "edit") {
-      clearSelection();
-      setBulkPromotionOpen(false);
-    }
-  };
-
-  const openBulkPromotion = () => {
-    if (selectedCount === 0) return;
-    setBulkPromotionOpen(true);
-  };
-
-  const openBulkDeleteConfirm = () => {
-    if (selectedCount === 0) return;
-    setDeleteConfirm({ mode: "phrase", products: selectedProducts });
-  };
-
-  const openInlineDeleteConfirm = (product: CatalogProduct) => {
-    setDeleteConfirm({ mode: "quick", products: [product] });
-  };
-
-  const confirmDelete = async () => {
-    if (!deleteConfirm || deleteConfirm.products.length === 0) return;
-    const productIds = deleteConfirm.products.map(product => product.id);
-
-    try {
-      if (deleteConfirm.mode === "quick") {
-        await onDeleteProduct(productIds[0]);
-      } else {
-        await onDeleteProducts(productIds);
-        clearSelection();
-      }
-      setDeleteConfirm(null);
-    } catch {
-      // The mutation layer sets catalogError; keep the dialog open so the user can retry or cancel.
-    }
-  };
+  const {
+    adminMode,
+    bulkMode,
+    bulkPromotionOpen,
+    closeBulkPromotion,
+    closeDeleteConfirm,
+    confirmDelete,
+    deleteConfirm,
+    openBulkDeleteConfirm,
+    openBulkPromotion,
+    openInlineDeleteConfirm,
+    setAdminMode
+  } = useCatalogAdminWorkflow({
+    clearSelection,
+    onDeleteProduct,
+    onDeleteProducts,
+    selectedCount,
+    selectedProducts
+  });
 
   return (
     <main className="admin-screen">
       <CatalogAdminHeader
         mode={adminMode}
         onBackToPrint={onBackToPrint}
-        onModeChange={toggleAdminMode}
+        onModeChange={setAdminMode}
         onStartAdding={startAdding}
       />
 
@@ -195,7 +166,7 @@ const CatalogAdminScreen = ({
       {bulkPromotionOpen ? (
         <BulkPromotionModal
           onApply={onApplyBulkPromotion}
-          onClose={() => setBulkPromotionOpen(false)}
+          onClose={closeBulkPromotion}
           products={selectedProducts}
         />
       ) : null}
@@ -203,7 +174,7 @@ const CatalogAdminScreen = ({
       {deleteConfirm ? (
         <DeleteConfirmModal
           mode={deleteConfirm.mode}
-          onCancel={() => setDeleteConfirm(null)}
+          onCancel={closeDeleteConfirm}
           onConfirm={() => void confirmDelete()}
           products={deleteConfirm.products}
         />

--- a/src/features/catalog/useCatalogAdminWorkflow.test.tsx
+++ b/src/features/catalog/useCatalogAdminWorkflow.test.tsx
@@ -1,0 +1,90 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
+import { useCatalogAdminWorkflow } from "./useCatalogAdminWorkflow";
+
+const products: CatalogProduct[] = [
+  {
+    brand: "Kross",
+    discountEnabled: false,
+    discountPrice: 0,
+    id: "item-1",
+    model: "Level",
+    price: 1000,
+    year: 2026,
+    yearLabel: "2026"
+  },
+  {
+    brand: "Giant",
+    discountEnabled: false,
+    discountPrice: 0,
+    id: "item-2",
+    model: "Talon",
+    price: 2000,
+    year: 2025,
+    yearLabel: "2025"
+  }
+];
+
+function renderWorkflow(overrides: Partial<Parameters<typeof useCatalogAdminWorkflow>[0]> = {}) {
+  const options = {
+    clearSelection: vi.fn(),
+    onDeleteProduct: vi.fn(async () => undefined),
+    onDeleteProducts: vi.fn(async () => undefined),
+    selectedCount: products.length,
+    selectedProducts: products,
+    ...overrides
+  };
+
+  return {
+    options,
+    ...renderHook(() => useCatalogAdminWorkflow(options))
+  };
+}
+
+describe("useCatalogAdminWorkflow", () => {
+  it("clears selection and closes promotion when leaving bulk mode", () => {
+    const { options, result } = renderWorkflow();
+
+    act(() => result.current.setAdminMode("bulk"));
+    act(() => result.current.openBulkPromotion());
+    expect(result.current.bulkPromotionOpen).toBe(true);
+
+    act(() => result.current.setAdminMode("edit"));
+
+    expect(result.current.bulkMode).toBe(false);
+    expect(result.current.bulkPromotionOpen).toBe(false);
+    expect(options.clearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirms bulk deletes and clears selection", async () => {
+    const { options, result } = renderWorkflow();
+
+    act(() => result.current.openBulkDeleteConfirm());
+    expect(result.current.deleteConfirm).toMatchObject({ mode: "phrase", products });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(options.onDeleteProducts).toHaveBeenCalledWith(["item-1", "item-2"]);
+    expect(options.clearSelection).toHaveBeenCalledTimes(1);
+    expect(result.current.deleteConfirm).toBeNull();
+  });
+
+  it("keeps delete confirmation open when deletion fails", async () => {
+    const onDeleteProduct = vi.fn(async () => {
+      throw new Error("delete failed");
+    });
+    const { result } = renderWorkflow({ onDeleteProduct });
+
+    act(() => result.current.openInlineDeleteConfirm(products[0]));
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(onDeleteProduct).toHaveBeenCalledWith("item-1");
+    expect(result.current.deleteConfirm).toMatchObject({ mode: "quick", products: [products[0]] });
+  });
+});

--- a/src/features/catalog/useCatalogAdminWorkflow.ts
+++ b/src/features/catalog/useCatalogAdminWorkflow.ts
@@ -1,0 +1,104 @@
+import { useCallback, useState } from "react";
+import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
+import type { CatalogAdminMode } from "./catalogAdminTypes";
+
+export type CatalogDeleteConfirmState = {
+  mode: "quick" | "phrase";
+  products: CatalogProduct[];
+};
+
+type UseCatalogAdminWorkflowOptions = {
+  clearSelection(): void;
+  onDeleteProduct(productId: string): Promise<void>;
+  onDeleteProducts(productIds: string[]): Promise<void>;
+  selectedCount: number;
+  selectedProducts: CatalogProduct[];
+};
+
+export type CatalogAdminWorkflowState = {
+  adminMode: CatalogAdminMode;
+  bulkMode: boolean;
+  bulkPromotionOpen: boolean;
+  deleteConfirm: CatalogDeleteConfirmState | null;
+  closeBulkPromotion(): void;
+  confirmDelete(): Promise<void>;
+  closeDeleteConfirm(): void;
+  openBulkDeleteConfirm(): void;
+  openBulkPromotion(): void;
+  openInlineDeleteConfirm(product: CatalogProduct): void;
+  setAdminMode(nextMode: CatalogAdminMode): void;
+};
+
+export function useCatalogAdminWorkflow({
+  clearSelection,
+  onDeleteProduct,
+  onDeleteProducts,
+  selectedCount,
+  selectedProducts
+}: UseCatalogAdminWorkflowOptions): CatalogAdminWorkflowState {
+  const [adminMode, setAdminModeState] = useState<CatalogAdminMode>("edit");
+  const [bulkPromotionOpen, setBulkPromotionOpen] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<CatalogDeleteConfirmState | null>(null);
+  const bulkMode = adminMode === "bulk";
+
+  const setAdminMode = useCallback((nextMode: CatalogAdminMode) => {
+    setAdminModeState(nextMode);
+    if (nextMode === "edit") {
+      clearSelection();
+      setBulkPromotionOpen(false);
+    }
+  }, [clearSelection]);
+
+  const openBulkPromotion = useCallback(() => {
+    if (selectedCount === 0) return;
+    setBulkPromotionOpen(true);
+  }, [selectedCount]);
+
+  const closeBulkPromotion = useCallback(() => {
+    setBulkPromotionOpen(false);
+  }, []);
+
+  const openBulkDeleteConfirm = useCallback(() => {
+    if (selectedCount === 0) return;
+    setDeleteConfirm({ mode: "phrase", products: selectedProducts });
+  }, [selectedCount, selectedProducts]);
+
+  const openInlineDeleteConfirm = useCallback((product: CatalogProduct) => {
+    setDeleteConfirm({ mode: "quick", products: [product] });
+  }, []);
+
+  const closeDeleteConfirm = useCallback(() => {
+    setDeleteConfirm(null);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteConfirm || deleteConfirm.products.length === 0) return;
+    const productIds = deleteConfirm.products.map(product => product.id);
+
+    try {
+      if (deleteConfirm.mode === "quick") {
+        await onDeleteProduct(productIds[0]);
+      } else {
+        await onDeleteProducts(productIds);
+        clearSelection();
+      }
+      setDeleteConfirm(null);
+    } catch {
+      // The mutation layer sets catalogError; keep the dialog open so the user can retry or cancel.
+    }
+  }, [clearSelection, deleteConfirm, onDeleteProduct, onDeleteProducts]);
+
+  return {
+    adminMode,
+    bulkMode,
+    bulkPromotionOpen,
+    closeBulkPromotion,
+    closeDeleteConfirm,
+    confirmDelete,
+    deleteConfirm,
+    openBulkDeleteConfirm,
+    openBulkPromotion,
+    openInlineDeleteConfirm,
+    setAdminMode
+  };
+}


### PR DESCRIPTION
## Summary
- extract catalog admin mode, bulk modal, and delete-confirmation orchestration into useCatalogAdminWorkflow
- keep CatalogAdminScreen focused on composing editor, selection, table, and modal UI
- add hook tests for mode switching, bulk delete confirmation, and failed quick-delete retry behavior

## Audit item
- addresses #5: admin state orchestration concentrated in CatalogAdminScreen

## Verification
- pnpm typecheck
- pnpm test -- src/features/catalog/useCatalogAdminWorkflow.test.tsx src/features/catalog/CatalogAdminScreen.test.tsx
- pnpm lint
- pnpm build
- pnpm test:e2e