### PR TITLE
Split catalog editor hook responsibilities

### DIFF
--- a/src/features/catalog/useCatalogAddFlow.ts
+++ b/src/features/catalog/useCatalogAddFlow.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from "react";
+import type { CatalogItemInput } from "../../domains/catalog/catalogItem";
+import {
+  catalogDraftToItem,
+  emptyCatalogDraft,
+  isDraftValid,
+  type CatalogDraft
+} from "../../domains/catalog/catalogDraft";
+import {
+  ALL_BRANDS,
+  ALL_YEARS
+} from "../../domains/catalog/catalogFilter";
+
+type UseCatalogAddFlowOptions = {
+  activeBrand: string;
+  activeYear: string;
+  onAddProduct(item: CatalogItemInput): Promise<void>;
+};
+
+export type CatalogAddFlowState = {
+  adding: boolean;
+  newDraft: CatalogDraft;
+  addProduct(): Promise<void>;
+  setAdding(adding: boolean): void;
+  startAdding(): void;
+  updateNewDraft<K extends keyof CatalogDraft>(field: K, value: CatalogDraft[K]): void;
+};
+
+export function useCatalogAddFlow({
+  activeBrand,
+  activeYear,
+  onAddProduct
+}: UseCatalogAddFlowOptions): CatalogAddFlowState {
+  const [adding, setAdding] = useState(false);
+  const [newDraft, setNewDraft] = useState<CatalogDraft>(() => emptyCatalogDraft());
+
+  const updateNewDraft = useCallback(<K extends keyof CatalogDraft>(field: K, value: CatalogDraft[K]) => {
+    setNewDraft(current => ({ ...current, [field]: value }));
+  }, []);
+
+  const addProduct = useCallback(async () => {
+    if (!isDraftValid(newDraft)) return;
+    await onAddProduct(catalogDraftToItem(newDraft));
+    setNewDraft(emptyCatalogDraft());
+    setAdding(false);
+  }, [newDraft, onAddProduct]);
+
+  const startAdding = useCallback(() => {
+    setNewDraft({
+      ...emptyCatalogDraft(),
+      brand: activeBrand === ALL_BRANDS ? "" : activeBrand,
+      year: activeYear === ALL_YEARS ? String(new Date().getFullYear()) : activeYear
+    });
+    setAdding(true);
+  }, [activeBrand, activeYear]);
+
+  return {
+    adding,
+    addProduct,
+    newDraft,
+    setAdding,
+    startAdding,
+    updateNewDraft
+  };
+}

--- a/src/features/catalog/useCatalogDraftEditor.ts
+++ b/src/features/catalog/useCatalogDraftEditor.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  draftFromItem,
+  type CatalogDraft
+} from "../../domains/catalog/catalogDraft";
+import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
+
+export type CatalogDraftEditorState = {
+  drafts: Record<string, CatalogDraft>;
+  editedCount: number;
+  cancelEdit(productId: string): void;
+  startEdit(product: CatalogProduct): void;
+  updateDraft<K extends keyof CatalogDraft>(productId: string, field: K, value: CatalogDraft[K]): void;
+};
+
+export function useCatalogDraftEditor(): CatalogDraftEditorState {
+  const [drafts, setDrafts] = useState<Record<string, CatalogDraft>>({});
+
+  const updateDraft = useCallback(<K extends keyof CatalogDraft>(productId: string, field: K, value: CatalogDraft[K]) => {
+    setDrafts(current => ({
+      ...current,
+      [productId]: {
+        ...current[productId],
+        [field]: value
+      }
+    }));
+  }, []);
+
+  const startEdit = useCallback((product: CatalogProduct) => {
+    setDrafts(current => ({
+      ...current,
+      [product.id]: draftFromItem(product)
+    }));
+  }, []);
+
+  const cancelEdit = useCallback((productId: string) => {
+    setDrafts(current => {
+      const next = { ...current };
+      delete next[productId];
+      return next;
+    });
+  }, []);
+
+  const editedCount = useMemo(() => Object.keys(drafts).length, [drafts]);
+
+  return {
+    cancelEdit,
+    drafts,
+    editedCount,
+    startEdit,
+    updateDraft
+  };
+}

--- a/src/features/catalog/useCatalogEditSave.ts
+++ b/src/features/catalog/useCatalogEditSave.ts
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import type { CatalogItemInput } from "../../domains/catalog/catalogItem";
+import {
+  catalogDraftToItem,
+  isDraftDirty,
+  isDraftValid,
+  type CatalogDraft
+} from "../../domains/catalog/catalogDraft";
+import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
+
+type UseCatalogEditSaveOptions = {
+  drafts: Record<string, CatalogDraft>;
+  onUpdateProduct(productId: string, item: CatalogItemInput): Promise<void>;
+  onSaved(productId: string): void;
+};
+
+export type CatalogEditSaveState = {
+  saveEdit(product: CatalogProduct): Promise<void>;
+};
+
+export function useCatalogEditSave({
+  drafts,
+  onSaved,
+  onUpdateProduct
+}: UseCatalogEditSaveOptions): CatalogEditSaveState {
+  const saveEdit = useCallback(async (product: CatalogProduct) => {
+    const draft = drafts[product.id];
+    if (!draft || !isDraftValid(draft) || !isDraftDirty(product, draft)) return;
+    await onUpdateProduct(product.id, catalogDraftToItem(draft));
+    onSaved(product.id);
+  }, [drafts, onSaved, onUpdateProduct]);
+
+  return { saveEdit };
+}

--- a/src/features/catalog/useCatalogEditor.test.tsx
+++ b/src/features/catalog/useCatalogEditor.test.tsx
@@ -1,0 +1,168 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
+import { useCatalogEditor } from "./useCatalogEditor";
+
+const products: CatalogProduct[] = [
+  {
+    brand: "Kross",
+    discountEnabled: false,
+    discountPrice: 0,
+    id: "item-2026",
+    model: "Level",
+    price: 1000,
+    year: 2026,
+    yearLabel: "2026"
+  },
+  {
+    brand: "Giant",
+    discountEnabled: false,
+    discountPrice: 0,
+    id: "item-2025",
+    model: "Talon",
+    price: 2000,
+    year: 2025,
+    yearLabel: "2025"
+  },
+  {
+    brand: "Trek",
+    discountEnabled: true,
+    discountPrice: 2500,
+    id: "item-2024",
+    model: "Marlin",
+    price: 3000,
+    year: 2024,
+    yearLabel: "2024"
+  }
+];
+
+function renderCatalogEditor(overrides: Partial<Parameters<typeof useCatalogEditor>[0]> = {}) {
+  const options: Parameters<typeof useCatalogEditor>[0] = {
+    brands: ["Giant", "Kross", "Trek"],
+    onAddProduct: vi.fn(async () => undefined),
+    onUpdateProduct: vi.fn(async () => undefined),
+    products,
+    ...overrides
+  };
+
+  return {
+    options,
+    ...renderHook((props: Parameters<typeof useCatalogEditor>[0]) => useCatalogEditor(props), {
+      initialProps: options
+    })
+  };
+}
+
+describe("useCatalogEditor", () => {
+  it("derives filter options, filtered products, and active fallback filters", () => {
+    const { options, result, rerender } = renderCatalogEditor();
+
+    expect(result.current.brandOptions.map(option => option.value)).toEqual([
+      "all",
+      "Giant",
+      "Kross",
+      "Trek"
+    ]);
+    expect(result.current.yearOptions.map(option => option.value)).toEqual([
+      "all",
+      "2026",
+      "2025",
+      "2024"
+    ]);
+
+    act(() => {
+      result.current.setBrand("Giant");
+      result.current.setYear("2025");
+      result.current.setQuery("tal");
+    });
+
+    expect(result.current.filteredProducts.map(product => product.id)).toEqual(["item-2025"]);
+
+    rerender({
+      ...options,
+      products: products.filter(product => product.id !== "item-2025")
+    });
+
+    expect(result.current.brand).toBe("all");
+    expect(result.current.year).toBe("all");
+  });
+
+  it("starts an add row from active filters and saves a valid new product", async () => {
+    const { options, result } = renderCatalogEditor();
+
+    act(() => {
+      result.current.setBrand("Giant");
+      result.current.setYear("2025");
+    });
+    act(() => result.current.startAdding());
+
+    expect(result.current.adding).toBe(true);
+    expect(result.current.newDraft).toMatchObject({
+      brand: "Giant",
+      year: "2025"
+    });
+
+    await act(async () => {
+      await result.current.addProduct();
+    });
+    expect(options.onAddProduct).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.updateNewDraft("brand", "  Orbea  ");
+      result.current.updateNewDraft("model", "  Laufey  ");
+      result.current.updateNewDraft("price", "4299");
+      result.current.updateNewDraft("discountEnabled", true);
+      result.current.updateNewDraft("discountPrice", "3999");
+    });
+
+    await act(async () => {
+      await result.current.addProduct();
+    });
+
+    expect(options.onAddProduct).toHaveBeenCalledWith({
+      brand: "Orbea",
+      discountEnabled: true,
+      discountPrice: 3999,
+      model: "Laufey",
+      price: 4299,
+      year: "2025"
+    });
+    expect(result.current.adding).toBe(false);
+  });
+
+  it("tracks edit drafts and saves only dirty valid products", async () => {
+    const { options, result } = renderCatalogEditor();
+    const product = products[0];
+
+    act(() => result.current.startEdit(product));
+
+    expect(result.current.editedCount).toBe(1);
+    expect(result.current.drafts[product.id]).toMatchObject({
+      brand: "Kross",
+      model: "Level"
+    });
+
+    await act(async () => {
+      await result.current.saveEdit(product);
+    });
+    expect(options.onUpdateProduct).not.toHaveBeenCalled();
+    expect(result.current.editedCount).toBe(1);
+
+    act(() => result.current.updateDraft(product.id, "model", "  Level X  "));
+
+    await act(async () => {
+      await result.current.saveEdit(product);
+    });
+
+    expect(options.onUpdateProduct).toHaveBeenCalledWith("item-2026", {
+      brand: "Kross",
+      discountEnabled: false,
+      discountPrice: 0,
+      model: "Level X",
+      price: 1000,
+      year: "2026"
+    });
+    expect(result.current.drafts[product.id]).toBeUndefined();
+    expect(result.current.editedCount).toBe(0);
+  });
+});

--- a/src/features/catalog/useCatalogEditor.ts
+++ b/src/features/catalog/useCatalogEditor.ts
@@ -1,21 +1,11 @@
-import { useCallback, useMemo, useState } from "react";
 import type { CatalogItemInput } from "../../domains/catalog/catalogItem";
-import {
-  catalogDraftToItem,
-  draftFromItem,
-  emptyCatalogDraft,
-  isDraftDirty,
-  isDraftValid,
-  type CatalogDraft
-} from "../../domains/catalog/catalogDraft";
-import {
-  ALL_BRANDS,
-  ALL_YEARS,
-  filterCatalogProducts,
-  getCatalogYears
-} from "../../domains/catalog/catalogFilter";
+import type { CatalogDraft } from "../../domains/catalog/catalogDraft";
 import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
 import type { CatalogFilterOption } from "./catalogAdminTypes";
+import { useCatalogAddFlow } from "./useCatalogAddFlow";
+import { useCatalogDraftEditor } from "./useCatalogDraftEditor";
+import { useCatalogEditorFilters } from "./useCatalogEditorFilters";
+import { useCatalogEditSave } from "./useCatalogEditSave";
 
 type UseCatalogEditorOptions = {
   brands: string[];
@@ -54,119 +44,40 @@ export function useCatalogEditor({
   onUpdateProduct,
   products
 }: UseCatalogEditorOptions): CatalogEditorState {
-  const [adding, setAdding] = useState(false);
-  const [brand, setBrand] = useState(ALL_BRANDS);
-  const [drafts, setDrafts] = useState<Record<string, CatalogDraft>>({});
-  const [newDraft, setNewDraft] = useState<CatalogDraft>(() => emptyCatalogDraft());
-  const [query, setQuery] = useState("");
-  const [year, setYear] = useState(ALL_YEARS);
-
-  const brandOptions = useMemo(
-    () => [
-      { label: "Wszystkie", value: ALL_BRANDS },
-      ...brands.map(item => ({ label: item, value: item }))
-    ],
-    [brands]
-  );
-
-  const yearOptions = useMemo(
-    () => [
-      { label: "Wszystkie", value: ALL_YEARS },
-      ...getCatalogYears(products).map(item => ({ label: item, value: item }))
-    ],
-    [products]
-  );
-
-  const productBrands = useMemo(
-    () => new Set(products.map(product => product.brand).filter(Boolean)),
-    [products]
-  );
-  const productYears = useMemo(
-    () => new Set(getCatalogYears(products)),
-    [products]
-  );
-
-  const activeBrand = brand === ALL_BRANDS || productBrands.has(brand) ? brand : ALL_BRANDS;
-  const activeYear = year === ALL_YEARS || productYears.has(year) ? year : ALL_YEARS;
-
-  const filteredProducts = useMemo(
-    () => filterCatalogProducts(products, { brand: activeBrand, query, year: activeYear }),
-    [activeBrand, activeYear, products, query]
-  );
-
-  const updateDraft = useCallback(<K extends keyof CatalogDraft>(productId: string, field: K, value: CatalogDraft[K]) => {
-    setDrafts(current => ({
-      ...current,
-      [productId]: {
-        ...current[productId],
-        [field]: value
-      }
-    }));
-  }, []);
-
-  const updateNewDraft = useCallback(<K extends keyof CatalogDraft>(field: K, value: CatalogDraft[K]) => {
-    setNewDraft(current => ({ ...current, [field]: value }));
-  }, []);
-
-  const startEdit = useCallback((product: CatalogProduct) => {
-    setDrafts(current => ({
-      ...current,
-      [product.id]: draftFromItem(product)
-    }));
-  }, []);
-
-  const cancelEdit = useCallback((productId: string) => {
-    setDrafts(current => {
-      const next = { ...current };
-      delete next[productId];
-      return next;
-    });
-  }, []);
-
-  const saveEdit = useCallback(async (product: CatalogProduct) => {
-    const draft = drafts[product.id];
-    if (!draft || !isDraftValid(draft) || !isDraftDirty(product, draft)) return;
-    await onUpdateProduct(product.id, catalogDraftToItem(draft));
-    cancelEdit(product.id);
-  }, [cancelEdit, drafts, onUpdateProduct]);
-
-  const addProduct = useCallback(async () => {
-    if (!isDraftValid(newDraft)) return;
-    await onAddProduct(catalogDraftToItem(newDraft));
-    setNewDraft(emptyCatalogDraft());
-    setAdding(false);
-  }, [newDraft, onAddProduct]);
-
-  const startAdding = useCallback(() => {
-    setNewDraft({
-      ...emptyCatalogDraft(),
-      brand: activeBrand === ALL_BRANDS ? "" : activeBrand,
-      year: activeYear === ALL_YEARS ? String(new Date().getFullYear()) : activeYear
-    });
-    setAdding(true);
-  }, [activeBrand, activeYear]);
+  const filters = useCatalogEditorFilters({ brands, products });
+  const draftEditor = useCatalogDraftEditor();
+  const addFlow = useCatalogAddFlow({
+    activeBrand: filters.brand,
+    activeYear: filters.year,
+    onAddProduct
+  });
+  const { saveEdit } = useCatalogEditSave({
+    drafts: draftEditor.drafts,
+    onSaved: draftEditor.cancelEdit,
+    onUpdateProduct
+  });
 
   return {
-    adding,
-    addProduct,
-    brand: activeBrand,
-    brandOptions,
-    cancelEdit,
-    drafts,
-    editedCount: Object.keys(drafts).length,
-    filteredProducts,
-    newDraft,
-    query,
+    adding: addFlow.adding,
+    addProduct: addFlow.addProduct,
+    brand: filters.brand,
+    brandOptions: filters.brandOptions,
+    cancelEdit: draftEditor.cancelEdit,
+    drafts: draftEditor.drafts,
+    editedCount: draftEditor.editedCount,
+    filteredProducts: filters.filteredProducts,
+    newDraft: addFlow.newDraft,
+    query: filters.query,
     saveEdit,
-    setAdding,
-    setBrand,
-    setQuery,
-    setYear,
-    startAdding,
-    startEdit,
-    updateDraft,
-    updateNewDraft,
-    year: activeYear,
-    yearOptions
+    setAdding: addFlow.setAdding,
+    setBrand: filters.setBrand,
+    setQuery: filters.setQuery,
+    setYear: filters.setYear,
+    startAdding: addFlow.startAdding,
+    startEdit: draftEditor.startEdit,
+    updateDraft: draftEditor.updateDraft,
+    updateNewDraft: addFlow.updateNewDraft,
+    year: filters.year,
+    yearOptions: filters.yearOptions
   };
 }

--- a/src/features/catalog/useCatalogEditorFilters.ts
+++ b/src/features/catalog/useCatalogEditorFilters.ts
@@ -1,0 +1,80 @@
+import { useMemo, useState } from "react";
+import {
+  ALL_BRANDS,
+  ALL_YEARS,
+  filterCatalogProducts,
+  getCatalogYears
+} from "../../domains/catalog/catalogFilter";
+import type { CatalogProduct } from "../../domains/catalog/catalogProduct";
+import type { CatalogFilterOption } from "./catalogAdminTypes";
+
+type UseCatalogEditorFiltersOptions = {
+  brands: string[];
+  products: CatalogProduct[];
+};
+
+export type CatalogEditorFiltersState = {
+  brand: string;
+  brandOptions: CatalogFilterOption[];
+  filteredProducts: CatalogProduct[];
+  query: string;
+  year: string;
+  yearOptions: CatalogFilterOption[];
+  setBrand(brand: string): void;
+  setQuery(query: string): void;
+  setYear(year: string): void;
+};
+
+export function useCatalogEditorFilters({
+  brands,
+  products
+}: UseCatalogEditorFiltersOptions): CatalogEditorFiltersState {
+  const [brand, setBrand] = useState(ALL_BRANDS);
+  const [query, setQuery] = useState("");
+  const [year, setYear] = useState(ALL_YEARS);
+
+  const brandOptions = useMemo(
+    () => [
+      { label: "Wszystkie", value: ALL_BRANDS },
+      ...brands.map(item => ({ label: item, value: item }))
+    ],
+    [brands]
+  );
+
+  const yearOptions = useMemo(
+    () => [
+      { label: "Wszystkie", value: ALL_YEARS },
+      ...getCatalogYears(products).map(item => ({ label: item, value: item }))
+    ],
+    [products]
+  );
+
+  const productBrands = useMemo(
+    () => new Set(products.map(product => product.brand).filter(Boolean)),
+    [products]
+  );
+  const productYears = useMemo(
+    () => new Set(getCatalogYears(products)),
+    [products]
+  );
+
+  const activeBrand = brand === ALL_BRANDS || productBrands.has(brand) ? brand : ALL_BRANDS;
+  const activeYear = year === ALL_YEARS || productYears.has(year) ? year : ALL_YEARS;
+
+  const filteredProducts = useMemo(
+    () => filterCatalogProducts(products, { brand: activeBrand, query, year: activeYear }),
+    [activeBrand, activeYear, products, query]
+  );
+
+  return {
+    brand: activeBrand,
+    brandOptions,
+    filteredProducts,
+    query,
+    setBrand,
+    setQuery,
+    setYear,
+    year: activeYear,
+    yearOptions
+  };
+}


### PR DESCRIPTION
## Summary
- keep useCatalogEditor as a composition hook while moving filter state and derived products into useCatalogEditorFilters
- move existing-row draft editing into useCatalogDraftEditor and edit persistence into useCatalogEditSave
- move add-row draft lifecycle into useCatalogAddFlow
- add focused hook coverage for filtering fallback, add flow, and dirty edit save behavior

## Verification
- pnpm typecheck
- pnpm test -- src/features/catalog/useCatalogEditor.test.tsx src/features/catalog/CatalogAdminScreen.test.tsx
- pnpm lint
- pnpm build