### PR TITLE
Move print count copy into language domain

### DIFF
--- a/src/domains/language/catalogCopy.ts
+++ b/src/domains/language/catalogCopy.ts
@@ -1,4 +1,4 @@
-import { getPolishPlural } from "../../domains/language/polishPlural";
+import { getPolishPlural } from "./polishPlural";
 
 export function selectedRowsLabel(count: number): string {
   return getPolishPlural(count, {

--- a/src/domains/language/printCopy.test.ts
+++ b/src/domains/language/printCopy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPrintableTagCountWord,
+  getPriceCountWord,
+  getPrintSheetCountWord,
+  getTagCountWord
+} from "./printCopy";
+
+describe("printCopy", () => {
+  it("uses Polish count forms for price labels", () => {
+    expect(getPriceCountWord(0)).toBe("cen");
+    expect(getPriceCountWord(1)).toBe("cena");
+    expect(getPriceCountWord(2)).toBe("ceny");
+    expect(getPriceCountWord(4)).toBe("ceny");
+    expect(getPriceCountWord(5)).toBe("cen");
+    expect(getPriceCountWord(11)).toBe("cen");
+    expect(getPriceCountWord(21)).toBe("cen");
+    expect(getPriceCountWord(22)).toBe("ceny");
+    expect(getPriceCountWord(24)).toBe("ceny");
+    expect(getPriceCountWord(25)).toBe("cen");
+    expect(getPriceCountWord(31)).toBe("cen");
+    expect(getPriceCountWord(32)).toBe("ceny");
+    expect(getPriceCountWord(112)).toBe("cen");
+    expect(getPriceCountWord(122)).toBe("ceny");
+  });
+
+  it("uses Polish count forms for tag labels", () => {
+    expect(getTagCountWord(0)).toBe("etykiet");
+    expect(getTagCountWord(1)).toBe("etykietę");
+    expect(getTagCountWord(2)).toBe("etykiety");
+    expect(getTagCountWord(5)).toBe("etykiet");
+    expect(getTagCountWord(22)).toBe("etykiety");
+    expect(getPrintableTagCountWord(0)).toBe("etykiet");
+    expect(getPrintableTagCountWord(1)).toBe("etykieta");
+    expect(getPrintableTagCountWord(2)).toBe("etykiety");
+    expect(getPrintableTagCountWord(5)).toBe("etykiet");
+    expect(getPrintableTagCountWord(22)).toBe("etykiety");
+  });
+
+  it("uses Polish count forms for sheet labels", () => {
+    expect(getPrintSheetCountWord(1)).toBe("arkusz");
+    expect(getPrintSheetCountWord(2)).toBe("arkusze");
+    expect(getPrintSheetCountWord(5)).toBe("arkuszy");
+    expect(getPrintSheetCountWord(22)).toBe("arkusze");
+  });
+});

--- a/src/domains/language/printCopy.ts
+++ b/src/domains/language/printCopy.ts
@@ -1,0 +1,33 @@
+import { getPolishPlural } from "./polishPlural";
+
+export function getPriceCountWord(count: number): "cena" | "ceny" | "cen" {
+  return getPolishPlural(count, {
+    one: "cena",
+    few: "ceny",
+    many: "cen"
+  });
+}
+
+export function getTagCountWord(count: number): "etykietę" | "etykiety" | "etykiet" {
+  return getPolishPlural(count, {
+    one: "etykietę",
+    few: "etykiety",
+    many: "etykiet"
+  });
+}
+
+export function getPrintableTagCountWord(count: number): "etykieta" | "etykiety" | "etykiet" {
+  return getPolishPlural(count, {
+    one: "etykieta",
+    few: "etykiety",
+    many: "etykiet"
+  });
+}
+
+export function getPrintSheetCountWord(count: number): "arkusz" | "arkusze" | "arkuszy" {
+  return getPolishPlural(count, {
+    one: "arkusz",
+    few: "arkusze",
+    many: "arkuszy"
+  });
+}

--- a/src/domains/printQueue/printQueue.test.ts
+++ b/src/domains/printQueue/printQueue.test.ts
@@ -3,11 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   addToPrintQueue,
   clearPrintQueue,
-  getPrintableTagCountWord,
-  getPriceCountWord,
-  getPrintSheetCountWord,
   getPrintQueueTotal,
-  getTagCountWord,
   parsePrintQueue,
   removeFromPrintQueue
 } from './printQueue';
@@ -47,47 +43,6 @@ describe('clearPrintQueue', () => {
 describe('getPrintQueueTotal', () => {
   it('counts the total number of tags to print', () => {
     expect(getPrintQueueTotal({ item1: 2, item2: 3 })).toBe(5);
-  });
-});
-
-describe('getPriceCountWord', () => {
-  it('uses Polish count forms for price labels', () => {
-    expect(getPriceCountWord(0)).toBe('cen');
-    expect(getPriceCountWord(1)).toBe('cena');
-    expect(getPriceCountWord(2)).toBe('ceny');
-    expect(getPriceCountWord(4)).toBe('ceny');
-    expect(getPriceCountWord(5)).toBe('cen');
-    expect(getPriceCountWord(11)).toBe('cen');
-    expect(getPriceCountWord(21)).toBe('cen');
-    expect(getPriceCountWord(22)).toBe('ceny');
-    expect(getPriceCountWord(24)).toBe('ceny');
-    expect(getPriceCountWord(25)).toBe('cen');
-    expect(getPriceCountWord(31)).toBe('cen');
-    expect(getPriceCountWord(32)).toBe('ceny');
-    expect(getPriceCountWord(112)).toBe('cen');
-    expect(getPriceCountWord(122)).toBe('ceny');
-  });
-});
-
-describe('print queue count labels', () => {
-  it('uses Polish count forms for tag labels', () => {
-    expect(getTagCountWord(0)).toBe('etykiet');
-    expect(getTagCountWord(1)).toBe('etykietę');
-    expect(getTagCountWord(2)).toBe('etykiety');
-    expect(getTagCountWord(5)).toBe('etykiet');
-    expect(getTagCountWord(22)).toBe('etykiety');
-    expect(getPrintableTagCountWord(0)).toBe('etykiet');
-    expect(getPrintableTagCountWord(1)).toBe('etykieta');
-    expect(getPrintableTagCountWord(2)).toBe('etykiety');
-    expect(getPrintableTagCountWord(5)).toBe('etykiet');
-    expect(getPrintableTagCountWord(22)).toBe('etykiety');
-  });
-
-  it('uses Polish count forms for sheet labels', () => {
-    expect(getPrintSheetCountWord(1)).toBe('arkusz');
-    expect(getPrintSheetCountWord(2)).toBe('arkusze');
-    expect(getPrintSheetCountWord(5)).toBe('arkuszy');
-    expect(getPrintSheetCountWord(22)).toBe('arkusze');
   });
 });
 

--- a/src/domains/printQueue/printQueue.ts
+++ b/src/domains/printQueue/printQueue.ts
@@ -1,5 +1,3 @@
-import { getPolishPlural } from '../language/polishPlural';
-
 export type PrintQueue = Record<string, number>;
 
 export function addToPrintQueue(queue: PrintQueue, itemId: string, quantity: number): PrintQueue {
@@ -27,38 +25,6 @@ export function clearPrintQueue(): PrintQueue {
 
 export function getPrintQueueTotal(queue: PrintQueue): number {
   return Object.values(queue).reduce((total, quantity) => total + quantity, 0);
-}
-
-export function getPriceCountWord(count: number): "cena" | "ceny" | "cen" {
-  return getPolishPlural(count, {
-    one: "cena",
-    few: "ceny",
-    many: "cen"
-  });
-}
-
-export function getTagCountWord(count: number): "etykietę" | "etykiety" | "etykiet" {
-  return getPolishPlural(count, {
-    one: "etykietę",
-    few: "etykiety",
-    many: "etykiet"
-  });
-}
-
-export function getPrintableTagCountWord(count: number): "etykieta" | "etykiety" | "etykiet" {
-  return getPolishPlural(count, {
-    one: "etykieta",
-    few: "etykiety",
-    many: "etykiet"
-  });
-}
-
-export function getPrintSheetCountWord(count: number): "arkusz" | "arkusze" | "arkuszy" {
-  return getPolishPlural(count, {
-    one: "arkusz",
-    few: "arkusze",
-    many: "arkuszy"
-  });
 }
 
 export function parsePrintQueue(value: unknown): PrintQueue {

--- a/src/features/printQueue/PrintQueuePanel.tsx
+++ b/src/features/printQueue/PrintQueuePanel.tsx
@@ -4,8 +4,10 @@ import QuantityStepper from "../../design-system/QuantityStepper";
 import {
   getPrintableTagCountWord,
   getPrintSheetCountWord,
+  getTagCountWord
+} from "../../domains/language/printCopy";
+import {
   getPrintQueueTotal,
-  getTagCountWord,
   type PrintQueue
 } from "../../domains/printQueue/printQueue";
 import { getPrintSheetCount } from "../../domains/printTagRendering/printTagRendering";


### PR DESCRIPTION
## Summary
- move print-related Polish count label helpers from `domains/printQueue` to `domains/language/printCopy`
- move the label tests beside the language domain helpers
- update `PrintQueuePanel` to import queue state behavior from `printQueue` and copy from `printCopy`
- fix the sibling `catalogCopy` import to use `./polishPlural`

## Validation
- import resolver audit across `src`, `tests`, and `scripts`: no missing or non-canonical imports
- pnpm typecheck
- pnpm lint
- git diff --check
- pnpm test
- pnpm build