### PR TITLE
Remove legacy brand catalog reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Realtime Database path:
 
 ```text
 profi-bike/
-  brands/
   items/
   owners/
   ownerUids/

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -46,7 +46,7 @@ Layer boundaries are enforced where practical in `eslint.config.js`:
 `src/App.tsx` wires the runtime services and main hooks:
 
 - `useAuthSession` observes Firebase Auth and exposes login/logout state.
-- `useCatalog` subscribes to Realtime Database catalog items and brands through `catalogRepository`.
+- `useCatalog` subscribes to Realtime Database catalog items through `catalogRepository` and derives brand filters from those items.
 - `usePrintQueue` manages persisted queue state through the storage domain.
 - `useCatalogMutations` writes catalog changes through the repository and lets realtime subscriptions refresh the UI.
 - `useBulkPromotionActions` applies promotion updates to selected products.
@@ -74,7 +74,6 @@ Database root:
 
 ```text
 profi-bike/
-  brands/
   items/
   owners/
   ownerUids/

--- a/scripts/seed-data.sample.json
+++ b/scripts/seed-data.sample.json
@@ -1,6 +1,5 @@
 {
   "profi-bike": {
-    "brands": ["Kross", "Giant"],
     "items": {
       "item-demo-1": {
         "discountPrice": 1499,

--- a/scripts/validate-prod-export.mjs
+++ b/scripts/validate-prod-export.mjs
@@ -109,16 +109,6 @@ function validateExport(data) {
     };
   }
 
-  if (!Array.isArray(store.brands)) {
-    errors.push('profi-bike/brands must be an array');
-  } else {
-    store.brands.forEach((brand, index) => {
-      if (typeof brand !== 'string' || brand.length === 0) {
-        errors.push(`profi-bike/brands/${index} must be a non-empty string`);
-      }
-    });
-  }
-
   if (!isRecord(store.items)) {
     errors.push('profi-bike/items must be an object keyed by item id');
   } else {
@@ -172,7 +162,6 @@ function validateExport(data) {
     errors,
     itemErrors,
     summary: {
-      brands: Array.isArray(store.brands) ? store.brands.length : 0,
       items: isRecord(store.items) ? Object.keys(store.items).length : 0,
       owners: Array.isArray(store.owners) ? store.owners.length : 0,
       ownerUids: isRecord(store.ownerUids) ? Object.keys(store.ownerUids).length : 0
@@ -211,5 +200,5 @@ if (failed) {
 
 console.log(`Production export validation passed for ${exportPath}.`);
 console.log(
-  `Validated ${result.summary.items} items, ${result.summary.brands} brands, ${result.summary.owners} owners, and ${result.summary.ownerUids} ownerUids.`
+  `Validated ${result.summary.items} items, ${result.summary.owners} owners, and ${result.summary.ownerUids} ownerUids.`
 );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -28,10 +28,6 @@ it('tracks screen changes and print workflow events', async () => {
     deleteCatalogItems: vi.fn(async () => undefined),
     saveCatalogItem: vi.fn(async () => undefined),
     saveCatalogItems: vi.fn(async () => undefined),
-    subscribeCatalogBrands: vi.fn(handlers => {
-      handlers.next(['KTM']);
-      return vi.fn();
-    }),
     subscribeCatalogItems: vi.fn(handlers => {
       handlers.next({
         item1: {

--- a/src/domains/catalog/catalog.test.ts
+++ b/src/domains/catalog/catalog.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  parseLegacyCatalogBrands,
   parseLegacyCatalogItem,
   parseLegacyCatalogItems
 } from './catalog';
@@ -91,15 +90,5 @@ describe('parseLegacyCatalogItems', () => {
         year: 2026
       }
     });
-  });
-});
-
-describe('parseLegacyCatalogBrands', () => {
-  it('keeps valid brand names from the legacy brands array', () => {
-    expect(parseLegacyCatalogBrands(['Kross', '', 'Giant', 123])).toEqual(['Kross', 'Giant']);
-  });
-
-  it('returns an empty array for invalid brand data', () => {
-    expect(parseLegacyCatalogBrands({ Kross: true })).toEqual([]);
   });
 });

--- a/src/domains/catalog/catalog.ts
+++ b/src/domains/catalog/catalog.ts
@@ -22,7 +22,6 @@ export type LegacyCatalogItem = {
 };
 
 export type LegacyCatalogItemsById = Record<string, LegacyCatalogItem>;
-export type CatalogBrands = string[];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -59,9 +58,4 @@ export function parseLegacyCatalogItems(value: unknown): LegacyCatalogItemsById 
     }
     return items;
   }, {});
-}
-
-export function parseLegacyCatalogBrands(value: unknown): CatalogBrands {
-  if (!Array.isArray(value)) return [];
-  return value.filter((brand): brand is string => typeof brand === 'string' && brand.length > 0);
 }

--- a/src/domains/catalog/catalogProduct.ts
+++ b/src/domains/catalog/catalogProduct.ts
@@ -1,4 +1,3 @@
-import type { CatalogBrands } from "./catalog";
 import type { CatalogItem, CatalogItemsById } from "./catalogItem";
 
 export type CatalogProduct = CatalogItem & {
@@ -14,11 +13,8 @@ export function catalogItemsToProducts(items: CatalogItemsById): CatalogProduct[
     .sort((a, b) => `${a.brand} ${a.model}`.localeCompare(`${b.brand} ${b.model}`, "pl"));
 }
 
-export function getCatalogBrands(products: CatalogProduct[], dbBrands: CatalogBrands = []): string[] {
+export function getCatalogBrands(products: CatalogProduct[]): string[] {
   const brands = new Set<string>();
-  dbBrands.forEach(brand => {
-    if (brand.trim()) brands.add(brand.trim());
-  });
   products.forEach(product => {
     if (product.brand.trim()) brands.add(product.brand.trim());
   });

--- a/src/domains/catalog/catalogViewModel.test.ts
+++ b/src/domains/catalog/catalogViewModel.test.ts
@@ -54,10 +54,10 @@ describe("catalog domain view models", () => {
     ]);
   });
 
-  it("uses DB brands and item-derived brands without duplicates", () => {
+  it("derives distinct brands from products", () => {
     const products = catalogItemsToProducts(catalogItems);
 
-    expect(getCatalogBrands(products, ["Trek", "Giant"])).toEqual(["Giant", "Kross", "Trek"]);
+    expect(getCatalogBrands(products)).toEqual(["Kross", "Trek"]);
   });
 
   it("composes case-insensitive search and brand filtering", () => {

--- a/src/features/bulkPromotion/useBulkPromotionActions.test.tsx
+++ b/src/features/bulkPromotion/useBulkPromotionActions.test.tsx
@@ -11,7 +11,6 @@ function createCatalogRepository(): CatalogRepository {
     deleteCatalogItems: vi.fn(async () => undefined),
     saveCatalogItem: vi.fn(async () => undefined),
     saveCatalogItems: vi.fn(async () => undefined),
-    subscribeCatalogBrands: vi.fn(() => vi.fn()),
     subscribeCatalogItems: vi.fn(() => vi.fn())
   };
 }

--- a/src/features/catalog/useCatalog.test.tsx
+++ b/src/features/catalog/useCatalog.test.tsx
@@ -1,7 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AuthUser } from "@/domains/auth/authUser";
-import type { CatalogBrands } from "@/domains/catalog/catalog";
 import type { CatalogItemsById } from "@/domains/catalog/catalogItem";
 import type {
   CatalogReadRepository,
@@ -17,14 +16,8 @@ type SubscriptionHandlers<T> = {
 
 function createCatalogRepository() {
   let itemHandlers: SubscriptionHandlers<CatalogItemsById> | null = null;
-  let brandHandlers: SubscriptionHandlers<CatalogBrands> | null = null;
   const unsubscribeItems = vi.fn();
-  const unsubscribeBrands = vi.fn();
   const repository: CatalogReadRepository = {
-    subscribeCatalogBrands: vi.fn(handlers => {
-      brandHandlers = handlers;
-      return unsubscribeBrands;
-    }),
     subscribeCatalogItems: vi.fn(handlers => {
       itemHandlers = handlers;
       return unsubscribeItems;
@@ -32,9 +25,6 @@ function createCatalogRepository() {
   };
 
   return {
-    emitBrands(brands: CatalogBrands) {
-      act(() => brandHandlers?.next(brands));
-    },
     emitItems(items: CatalogItemsById) {
       act(() => itemHandlers?.next(items));
     },
@@ -42,7 +32,6 @@ function createCatalogRepository() {
       act(() => itemHandlers?.error?.(error));
     },
     repository,
-    unsubscribeBrands,
     unsubscribeItems
   };
 }
@@ -61,8 +50,7 @@ const item = {
 
 describe("useCatalog", () => {
   it("subscribes after login and derives products and brands", () => {
-    const { emitBrands, emitItems, repository, unsubscribeBrands, unsubscribeItems } =
-      createCatalogRepository();
+    const { emitItems, repository, unsubscribeItems } = createCatalogRepository();
     const observability = createTestObservability();
     const { result, rerender, unmount } = renderHook(
       ({ currentUser }) => useCatalog(currentUser, repository, observability),
@@ -77,10 +65,8 @@ describe("useCatalog", () => {
 
     expect(result.current.catalogLoading).toBe(true);
     expect(repository.subscribeCatalogItems).toHaveBeenCalledTimes(1);
-    expect(repository.subscribeCatalogBrands).toHaveBeenCalledTimes(1);
 
     emitItems({ item1: item });
-    emitBrands(["KTM", "Trek"]);
 
     expect(observability.trackEvent).toHaveBeenCalledWith("catalog_load_success", {
       item_count: 1
@@ -101,7 +87,7 @@ describe("useCatalog", () => {
         yearLabel: "2026"
       }
     ]);
-    expect(result.current.brands).toEqual(["KTM", "Trek"]);
+    expect(result.current.brands).toEqual(["KTM"]);
 
     rerender({ currentUser: null });
 
@@ -110,9 +96,28 @@ describe("useCatalog", () => {
     expect(result.current.products).toEqual([]);
     expect(result.current.brands).toEqual([]);
     expect(unsubscribeItems).toHaveBeenCalledTimes(1);
-    expect(unsubscribeBrands).toHaveBeenCalledTimes(1);
 
     unmount();
+  });
+
+  it("drops a brand option when the last product for that brand disappears", () => {
+    const { emitItems, repository } = createCatalogRepository();
+    const observability = createTestObservability();
+    const { result } = renderHook(() => useCatalog(user, repository, observability));
+
+    emitItems({
+      item1: item,
+      item2: {
+        ...item,
+        brand: "Trek",
+        id: "item2",
+        model: "Marlin"
+      }
+    });
+    expect(result.current.brands).toEqual(["KTM", "Trek"]);
+
+    emitItems({ item1: item });
+    expect(result.current.brands).toEqual(["KTM"]);
   });
 
   it("maps permission errors to the catalog access message", () => {

--- a/src/features/catalog/useCatalog.ts
+++ b/src/features/catalog/useCatalog.ts
@@ -5,7 +5,6 @@ import {
   getCatalogErrorMessage,
   type CatalogErrorHandler
 } from "./catalogErrors";
-import type { CatalogBrands } from "@/domains/catalog/catalog";
 import type { CatalogItemsById } from "@/domains/catalog/catalogItem";
 import type { CatalogReadRepository } from "@/services/firebase";
 import {
@@ -20,15 +19,12 @@ import {
 } from "@/domains/catalog/catalogProduct";
 
 type CatalogDataState = {
-  brands: CatalogBrands;
-  brandsLoadedForUid: string | null;
   error: string;
   items: CatalogItemsById;
   itemsLoadedForUid: string | null;
 };
 
 const emptyCatalogItems: CatalogItemsById = {};
-const emptyCatalogBrands: CatalogBrands = [];
 
 export type CatalogState = {
   brands: string[];
@@ -47,8 +43,6 @@ export function useCatalog(
   const activeUid = currentUser?.uid ?? null;
   const trackedCatalogLoadsRef = useRef(new Set<string>());
   const [catalogData, setCatalogData] = useState<CatalogDataState>({
-    brands: [],
-    brandsLoadedForUid: null,
     error: "",
     items: {},
     itemsLoadedForUid: null
@@ -83,35 +77,18 @@ export function useCatalog(
       }
     });
 
-    const unsubscribeBrands = repository.subscribeCatalogBrands({
-      next: brands => {
-        setCatalogData(currentData => ({
-          ...currentData,
-          brands,
-          brandsLoadedForUid: activeUid
-        }));
-      },
-      error: error => {
-        handleCatalogError(error);
-        workflowTelemetry.trackCatalogLoadFailure(observability, "catalog.subscribe_brands", error);
-      }
-    });
-
     return () => {
       unsubscribeItems();
-      unsubscribeBrands();
     };
   }, [activeUid, handleCatalogError, observability, repository]);
 
   const catalogItems =
     activeUid && catalogData.itemsLoadedForUid === activeUid ? catalogData.items : emptyCatalogItems;
-  const catalogBrands =
-    activeUid && catalogData.brandsLoadedForUid === activeUid ? catalogData.brands : emptyCatalogBrands;
   const catalogError = activeUid ? catalogData.error : "";
   const catalogLoading = Boolean(activeUid && catalogData.itemsLoadedForUid !== activeUid && !catalogError);
 
   const products = useMemo(() => catalogItemsToProducts(catalogItems), [catalogItems]);
-  const brands = useMemo(() => getCatalogBrands(products, catalogBrands), [catalogBrands, products]);
+  const brands = useMemo(() => getCatalogBrands(products), [products]);
 
   return {
     brands,

--- a/src/features/catalog/useCatalogMutations.test.tsx
+++ b/src/features/catalog/useCatalogMutations.test.tsx
@@ -11,7 +11,6 @@ function createCatalogRepository(): CatalogRepository {
     deleteCatalogItems: vi.fn(async () => undefined),
     saveCatalogItem: vi.fn(async () => undefined),
     saveCatalogItems: vi.fn(async () => undefined),
-    subscribeCatalogBrands: vi.fn(() => vi.fn()),
     subscribeCatalogItems: vi.fn(() => vi.fn())
   };
 }

--- a/src/services/firebase/catalogRepository.test.ts
+++ b/src/services/firebase/catalogRepository.test.ts
@@ -10,7 +10,6 @@ import {
 
 describe('catalogPaths', () => {
   it('centralizes legacy Realtime Database paths', () => {
-    expect(catalogPaths.brands()).toBe('profi-bike/brands');
     expect(catalogPaths.items()).toBe('profi-bike/items');
     expect(catalogPaths.item('item1')).toBe('profi-bike/items/item1');
   });

--- a/src/services/firebase/catalogRepository.ts
+++ b/src/services/firebase/catalogRepository.ts
@@ -1,10 +1,8 @@
-import { get, onValue, ref, remove, set, update, type Database } from 'firebase/database';
+import { onValue, ref, remove, set, update, type Database } from 'firebase/database';
 
 import {
-  parseLegacyCatalogBrands,
   parseLegacyCatalogItem,
   parseLegacyCatalogItems,
-  type CatalogBrands,
   type LegacyCatalogItem,
   type LegacyCatalogItemsById
 } from '@/domains/catalog/catalog';
@@ -20,9 +18,6 @@ import type { RepositoryError } from './repositoryError';
 export const defaultStoreId = 'profi-bike';
 
 export const catalogPaths = {
-  brands(storeId = defaultStoreId) {
-    return `${storeId}/brands`;
-  },
   items(storeId = defaultStoreId) {
     return `${storeId}/items`;
   },
@@ -40,7 +35,6 @@ export type SubscriptionHandlers<T> = {
 
 export type CatalogReadRepository = {
   subscribeCatalogItems(handlers: SubscriptionHandlers<CatalogItemsById>): () => void;
-  subscribeCatalogBrands(handlers: SubscriptionHandlers<CatalogBrands>): () => void;
 };
 
 export type CatalogWriteRepository = {
@@ -97,13 +91,6 @@ export function createCatalogRepository(
         firebaseError => error?.(toFirebaseRepositoryError(firebaseError))
       );
     },
-    subscribeCatalogBrands({ next, error }) {
-      return onValue(
-        ref(database, catalogPaths.brands(storeId)),
-        snapshot => next(parseLegacyCatalogBrands(snapshot.val())),
-        firebaseError => error?.(toFirebaseRepositoryError(firebaseError))
-      );
-    },
     saveCatalogItem(itemId, item) {
       return set(
         ref(database, catalogPaths.item(itemId, storeId)),
@@ -128,9 +115,4 @@ export function createCatalogRepository(
       return update(ref(database, catalogPaths.items(storeId)), createCatalogItemsDeletePayload(itemIds));
     }
   };
-}
-
-export async function readCatalogBrands(database: Database, storeId = defaultStoreId): Promise<CatalogBrands> {
-  const snapshot = await get(ref(database, catalogPaths.brands(storeId)));
-  return parseLegacyCatalogBrands(snapshot.val());
 }

--- a/src/services/firebase/index.ts
+++ b/src/services/firebase/index.ts
@@ -6,7 +6,6 @@ export {
   catalogPaths,
   createCatalogRepository,
   isPermissionDenied,
-  readCatalogBrands,
   toFirebaseRepositoryError
 } from './catalogRepository';
 export type {

--- a/src/services/observability/workflowTelemetry.ts
+++ b/src/services/observability/workflowTelemetry.ts
@@ -3,7 +3,7 @@ import type { RepositoryError } from "@/services/firebase/repositoryError";
 import { countTelemetryItems } from "./countTelemetryItems";
 import type { ObservabilityService } from "./types";
 
-type CatalogLoadOperation = "catalog.subscribe_items" | "catalog.subscribe_brands";
+type CatalogLoadOperation = "catalog.subscribe_items";
 type CatalogMutationOperation = "catalog.create" | "catalog.update" | "catalog.delete";
 
 export const workflowTelemetry = {

--- a/tests/catalogRepository.rules.test.ts
+++ b/tests/catalogRepository.rules.test.ts
@@ -140,12 +140,13 @@ function unauthenticatedDatabase(): Database {
 }
 
 describe('CatalogRepository security rules integration', () => {
-  it('allows an owner to read and write brands and items', async () => {
+  it('keeps temporary owner access to legacy brands while allowing item writes', async () => {
     await seedOwner();
 
     const repository = authenticatedRepository('owner-uid');
     const database = authenticatedDatabase('owner-uid');
 
+    // PR1 keeps this legacy node available for already deployed clients. PR2 will deny it.
     await assertSucceeds(set(ref(database, 'profi-bike/brands'), ['Kross']));
     await assertSucceeds(get(ref(database, 'profi-bike/brands')));
     await assertSucceeds(repository.saveCatalogItem('item-1', validCatalogItem));

--- a/tests/e2e/catalog-admin.spec.ts
+++ b/tests/e2e/catalog-admin.spec.ts
@@ -1,5 +1,18 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { gotoApp, openCatalogAdmin } from './helpers';
+
+async function addAdminProduct(page: Page, brand: string, model: string): Promise<void> {
+  await page.getByRole('button', { name: 'Dodaj produkt' }).click();
+
+  const addRow = page.getByTestId('admin-add-row');
+  await addRow.getByLabel('Marka').fill(brand);
+  await addRow.getByLabel('Model').fill(model);
+  await addRow.getByLabel('Rocznik').fill('2026');
+  await addRow.getByLabel('Cena katalogowa').fill('999');
+  await addRow.getByRole('button', { name: 'Zapisz' }).click();
+
+  await expect(page.getByTestId('admin-product-row').filter({ hasText: model })).toBeVisible();
+}
 
 test('creates, edits, and deletes a catalog product', async ({ page }) => {
   await gotoApp(page);
@@ -33,6 +46,34 @@ test('creates, edits, and deletes a catalog product', async ({ page }) => {
   await confirmDialog.getByRole('button', { name: 'Usuń 1' }).click();
 
   await expect(row).toHaveCount(0);
+});
+
+test('bulk deleting all products for an active brand removes that brand filter', async ({ page }) => {
+  await gotoApp(page);
+  await openCatalogAdmin(page);
+
+  const brand = 'E2E Vanishing Brand';
+  await addAdminProduct(page, brand, 'E2E Vanish First');
+  await addAdminProduct(page, brand, 'E2E Vanish Second');
+
+  const brandFilters = page.getByRole('group', { name: 'Filtr marki' });
+  await brandFilters.getByRole('button', { name: brand }).click();
+  await expect(brandFilters.getByRole('button', { name: brand, pressed: true })).toBeVisible();
+  await expect(page.getByTestId('admin-product-row')).toHaveCount(2);
+
+  await page.getByRole('group', { name: 'Tryb edycji cennika' }).getByRole('button', { name: 'Edycja zbiorcza' }).click();
+  await page.getByLabel('Zaznacz wszystko').check();
+  await page.getByRole('button', { name: 'Usuń' }).click();
+
+  const confirmDialog = page.getByRole('dialog', { name: /Usuń 2 produkty/ });
+  await expect(confirmDialog).toBeVisible();
+  await expect(confirmDialog.getByRole('button', { name: 'Usuń 2' })).toBeDisabled();
+  await confirmDialog.getByLabel('Potwierdzenie usunięcia').fill('usuń');
+  await confirmDialog.getByRole('button', { name: 'Usuń 2' }).click();
+
+  await expect(page.getByTestId('admin-product-row').filter({ hasText: brand })).toHaveCount(0);
+  await expect(brandFilters.getByRole('button', { name: brand })).toHaveCount(0);
+  await expect(brandFilters.getByRole('button', { name: 'Wszystkie', pressed: true })).toBeVisible();
 });
 
 test('bulk deletes selected catalog products with typed confirmation', async ({ page }) => {

--- a/tests/e2e/seed-data.json
+++ b/tests/e2e/seed-data.json
@@ -1,6 +1,5 @@
 {
   "profi-bike": {
-    "brands": ["Cannondale", "Giant", "Kross", "Trek"],
     "items": {
       "item-e2e-bulk": {
         "discountPrice": 0,


### PR DESCRIPTION
## Summary
- derive brand filters exclusively from catalog items
- remove the client repository API/parser/type surface for the legacy `profi-bike/brands` node
- update seeds, docs, export validation, and tests for the item-derived brand model
- add e2e coverage for bulk-deleting all products for an active brand and falling back to `Wszystkie`

## Compatibility
- leaves `database.rules.json` permissive for `profi-bike/brands` so already-deployed clients keep working until this app version is live

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm test:rules`
- `pnpm test:e2e`