### PR TITLE
Deny legacy brands database access and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Layer rules:
 - `src/features/`: screen workflows, hooks, forms, tables, modals, and user-action orchestration.
 - `src/domains/`: framework-free business rules, model conversions, validation, calculations, copy helpers, and storage helpers.
 - `src/services/`: Firebase and observability adapters behind typed facades.
-- `src/styles/`: physical print-tag styling.
+- `src/features/printTags/`: print-tag rendering components and physical print CSS.
 
 ESLint enforces the main layer boundaries. Do not bypass those rules with direct SDK imports or cross-layer shortcuts.
 
@@ -44,13 +44,12 @@ ESLint enforces the main layer boundaries. Do not bypass those rules with direct
 - The print workflow supports product search, brand filtering, sorting, queue quantities, clearing, and printing.
 - The catalog admin supports single-row editing, adding, deleting, bulk selection, bulk promotion, and typed-confirmation bulk delete.
 - User initials come from Firebase user identity.
-- Brand filters combine the database `brands` node with item-derived fallback brands.
-- The database `brands` node is an independent brand list; deleting all products for a brand does not automatically delete that brand entry.
+- Brand filters are derived from catalog items. The app does not read or write a separate `brands` node.
 - Catalog writes go through the repository layer and rely on realtime subscriptions to refresh catalog state.
 - New catalog item IDs are generated as collision-resistant `item-<uuid>` values in `useCatalogMutations`; preserve existing IDs when reading, updating, or deleting.
 - Polish product and print copy is intentional. Use helpers from `src/domains/language/` for pluralization.
 - Main product rows are not clickable add targets. Keep adding explicit through the `Dodaj` button and quantity stepper.
-- Keep print tag rendering separate from app chrome. The physical output uses `PrintTag` and `PrintTag.css`.
+- Keep print tag rendering separate from app chrome. The physical output uses `src/features/printTags/PrintTag.tsx` and `src/features/printTags/PrintTag.css`.
 
 ## Firebase And Data
 
@@ -70,7 +69,6 @@ Database shape:
 
 ```text
 profi-bike/
-  brands/
   items/
   owners/
   ownerUids/

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ profi-bike/
   ownerUids/
 ```
 
+Brand filters are derived from catalog items. The app does not read or write a separate `brands` node.
+
 Do not commit production exports, secrets, service account keys, or local emulator state.
 
 ## Deployment

--- a/database.rules.json
+++ b/database.rules.json
@@ -3,10 +3,6 @@
     ".read": false,
     ".write": false,
     "profi-bike": {
-      "brands": {
-        ".read": "auth != null && root.child('profi-bike/ownerUids/' + auth.uid).val() === true",
-        ".write": "auth != null && root.child('profi-bike/ownerUids/' + auth.uid).val() === true"
-      },
       "items": {
         ".read": "auth != null && root.child('profi-bike/ownerUids/' + auth.uid).val() === true",
         ".write": "auth != null && root.child('profi-bike/ownerUids/' + auth.uid).val() === true",

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -18,14 +18,12 @@ This repository contains the Profi Bike price-tag app. It is a narrow internal t
 ```text
 src/
   app/                 top-level shell, header, profile menu, and app mode types
-  components/          print-tag rendering components shared by screens
   design-system/       tokens, base CSS, and generic UI primitives
   domains/             framework-free catalog, pricing, language, queue, print, and storage helpers
-  features/            auth, catalog admin, product discovery, bulk promotion, and print queue UI
+  features/            auth, catalog admin, product discovery, bulk promotion, print queue, and print tags
   services/firebase/   Firebase config, Auth service, catalog repository, and runtime singletons
   services/observability/
                        Firebase Analytics and Sentry facade
-  styles/              physical print-tag CSS
   test/                shared test helpers
 tests/
   e2e/                 Playwright browser workflows with deterministic emulator data
@@ -94,6 +92,8 @@ Catalog items are persisted with these fields:
 
 The app maps that persisted shape to typed catalog items in `src/domains/catalog/catalogItem.ts`. Prices are display amounts in production data, not formally named cents fields.
 
+Brand filter options are derived from catalog item `name` values through the domain view-model helpers. The app does not read or write a separate `brands` node.
+
 Do not commit production exports, local emulator state, secrets, Firebase service accounts, or Sentry credentials.
 
 ## Local Development
@@ -128,7 +128,7 @@ The UI uses a restrained, utility-focused Profi Bike style with Carbon-inspired 
 
 - Generic tokens, base rules, and primitives live in `src/design-system/`.
 - Screen and workflow styling lives with the UI that owns it when styles are added or moved.
-- Physical printed tag output is separate from app chrome and uses `src/components/PrintTag.tsx` plus `src/styles/PrintTag.css`.
+- Physical printed tag output is separate from app chrome and uses `src/features/printTags/PrintTag.tsx` plus `src/features/printTags/PrintTag.css`.
 - Print CSS must keep app UI hidden during printing and preserve the A4 output layout.
 
 ## Observability

--- a/tests/catalogRepository.rules.test.ts
+++ b/tests/catalogRepository.rules.test.ts
@@ -140,15 +140,11 @@ function unauthenticatedDatabase(): Database {
 }
 
 describe('CatalogRepository security rules integration', () => {
-  it('keeps temporary owner access to legacy brands while allowing item writes', async () => {
+  it('allows an owner to read and write items', async () => {
     await seedOwner();
 
     const repository = authenticatedRepository('owner-uid');
-    const database = authenticatedDatabase('owner-uid');
 
-    // PR1 keeps this legacy node available for already deployed clients. PR2 will deny it.
-    await assertSucceeds(set(ref(database, 'profi-bike/brands'), ['Kross']));
-    await assertSucceeds(get(ref(database, 'profi-bike/brands')));
     await assertSucceeds(repository.saveCatalogItem('item-1', validCatalogItem));
     await assertSucceeds(repository.saveCatalogItems({
       'item-2': { ...validCatalogItem, model: 'Batch demo' }
@@ -161,6 +157,21 @@ describe('CatalogRepository security rules integration', () => {
     await assertSucceeds(repository.deleteCatalogItem('item-1'));
     await assertSucceeds(repository.deleteCatalogItem('item-2'));
     await expect(readItemsOnce(repository)).resolves.toEqual({});
+  });
+
+  it('denies legacy brands reads and writes for every client context', async () => {
+    await seedCatalogData();
+
+    const ownerDatabase = authenticatedDatabase('owner-uid');
+    const nonOwnerDatabase = authenticatedDatabase('other-uid');
+    const anonymousDatabase = unauthenticatedDatabase();
+
+    await assertFails(get(ref(ownerDatabase, 'profi-bike/brands')));
+    await assertFails(set(ref(ownerDatabase, 'profi-bike/brands'), ['Kross']));
+    await assertFails(get(ref(nonOwnerDatabase, 'profi-bike/brands')));
+    await assertFails(set(ref(nonOwnerDatabase, 'profi-bike/brands'), ['Kross']));
+    await assertFails(get(ref(anonymousDatabase, 'profi-bike/brands')));
+    await assertFails(set(ref(anonymousDatabase, 'profi-bike/brands'), ['Kross']));
   });
 
   it('allows an owner to read owners and ownerUids but denies client writes to both nodes', async () => {


### PR DESCRIPTION
## Summary
- remove the `profi-bike/brands` Realtime Database rules stanza so default-deny applies
- update rules integration coverage to assert owner, non-owner, and anonymous clients cannot read or write the unsupported brands node
- align `README.md`, `docs/codebase.md`, and `AGENTS.md` with the supported data shape and print-tag source paths
- keep owner item read/write behavior covered

## Rollout
- This is stacked on PR #29 and should not be merged/deployed until PR #29 is merged and the app version that no longer subscribes to `profi-bike/brands` is live.
- After these rules are deployed, manually back up/export and delete the existing production `profi-bike/brands` node.

## Verification
- `pnpm test:rules`
- `pnpm lint`
- `git diff --check`
- `pnpm typecheck`